### PR TITLE
Fix recursive lock

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -120,18 +120,17 @@ impl TransactionCache {
         F: FnOnce() -> Result<Vec<u8>>,
     {
         match self.map.lock().unwrap().get(txid) {
-            Some(serialized_txn) => Ok(deserialize(&serialized_txn).unwrap()),
-            None => {
-                let serialized_txn = load_txn_func()?;
-                let txn = deserialize(&serialized_txn).chain_err(|| "failed to parse cached tx")?;
-                let byte_size = 32 /* key (hash size) */ + serialized_txn.len();
-                self.map
-                    .lock()
-                    .unwrap()
-                    .put(*txid, serialized_txn, byte_size);
-                Ok(txn)
-            }
+            Some(serialized_txn) => return Ok(deserialize(&serialized_txn).unwrap()),
+            None => {}
         }
+        let serialized_txn = load_txn_func()?;
+        let txn = deserialize(&serialized_txn).chain_err(|| "failed to parse cached tx")?;
+        let byte_size = 32 /* key (hash size) */ + serialized_txn.len();
+        self.map
+            .lock()
+            .unwrap()
+            .put(*txid, serialized_txn, byte_size);
+        Ok(txn)
     }
 }
 


### PR DESCRIPTION
The match statement takes a lock, then a lock is attempted again when
putting an entry to the cache.