### PR TITLE
Replace PerodicUpdate with notifications

### DIFF
--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -62,12 +62,28 @@ fn run_server(config: &Config) -> Result<()> {
     let query = Query::new(app.clone(), &metrics, tx_cache, config.txid_limit);
 
     let mut server = None; // Electrum RPC server
+
+    // If we see this more new blocks than this, don't look for scripthash
+    // changes. Just have clients reconnect.
+    //
+    // This many header changes means we're either not fully synced, or there
+    // has been abnormally large reorg of the blockchain.
+    const MAX_SCRIPTHASH_BLOCKS: usize = 20;
+
     loop {
-        app.update(&signal)?;
-        query.update_mempool()?;
-        server
-            .get_or_insert_with(|| RPC::start(config.electrum_rpc_addr, query.clone(), &metrics))
-            .notify(); // update subscribed clients
+        let (headers_changed, new_tip) = app.update(&signal)?;
+        let txs_changed = query.update_mempool()?;
+        let rpc = server
+            .get_or_insert_with(|| RPC::start(config.electrum_rpc_addr, query.clone(), &metrics));
+        if headers_changed.len() > MAX_SCRIPTHASH_BLOCKS {
+            warn!("Large re-org, disconnecting clients");
+            rpc.disconnect_clients();
+        } else {
+            rpc.notify_scripthash_subscriptions(&headers_changed, txs_changed);
+        }
+        if let Some(header) = new_tip {
+            rpc.notify_subscriptions_chaintip(header);
+        }
         if let Err(err) = signal.wait(Duration::from_secs(5)) {
             info!("stopping server: {}", err);
             break;

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -163,7 +163,7 @@ fn load_headers(daemon: &Daemon) -> Result<HeaderList> {
     let tip = daemon.getbestblockhash()?;
     let mut headers = HeaderList::empty();
     let new_headers = headers.order(daemon.get_new_headers(&headers, &tip)?);
-    headers.apply(new_headers, tip);
+    headers.apply(&new_headers, tip);
     Ok(headers)
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -274,7 +274,7 @@ fn read_indexed_headers(store: &dyn ReadStore) -> HeaderList {
     );
     let mut result = HeaderList::empty();
     let entries = result.order(headers);
-    result.apply(entries, latest_blockhash);
+    result.apply(&entries, latest_blockhash);
     result
 }
 
@@ -366,7 +366,7 @@ impl Index {
 
     pub fn best_header(&self) -> Option<HeaderEntry> {
         let headers = self.headers.read().unwrap();
-        headers.header_by_blockhash(&headers.tip()).cloned()
+        headers.header_by_blockhash(&headers.tiphash()).cloned()
     }
 
     pub fn get_header(&self, height: usize) -> Option<HeaderEntry> {
@@ -377,7 +377,11 @@ impl Index {
             .cloned()
     }
 
-    pub fn update(&self, store: &impl WriteStore, waiter: &Waiter) -> Result<Sha256dHash> {
+    pub fn update(
+        &self,
+        store: &impl WriteStore,
+        waiter: &Waiter,
+    ) -> Result<(Vec<HeaderEntry>, HeaderEntry)> {
         let daemon = self.daemon.reconnect()?;
         let tip = daemon.getbestblockhash()?;
         let new_headers: Vec<HeaderEntry> = {
@@ -436,10 +440,16 @@ impl Index {
         timer.observe_duration();
 
         fetcher.join().expect("block fetcher failed");
-        self.headers.write().unwrap().apply(new_headers, tip);
-        assert_eq!(tip, self.headers.read().unwrap().tip());
+        self.headers.write().unwrap().apply(&new_headers, tip);
+        let tip_header = self
+            .headers
+            .read()
+            .unwrap()
+            .tip()
+            .expect("failed to get tip header");
+        assert_eq!(&tip, tip_header.hash());
         self.stats
             .update_height(self.headers.read().unwrap().len() - 1);
-        Ok(tip)
+        Ok((new_headers, tip_header))
     }
 }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -190,7 +190,10 @@ impl Tracker {
         &self.index
     }
 
-    pub fn update(&mut self, daemon: &Daemon) -> Result<()> {
+    pub fn update(&mut self, daemon: &Daemon) -> Result<HashSet<Sha256dHash>> {
+        // set of transactions where a change has occurred (either new or removed)
+        let mut changed_txs: HashSet<Sha256dHash> = HashSet::new();
+
         let timer = self.stats.start_timer("fetch");
         let new_txids = daemon
             .getmempooltxids()
@@ -216,20 +219,25 @@ impl Tracker {
             let txs = match daemon.gettransactions(&txids) {
                 Ok(txs) => txs,
                 Err(err) => {
-                    warn!("failed to get transactions {:?}: {}", txids, err); // e.g. new block or RBF
-                    return Ok(()); // keep the mempool until next update()
+                    // e.g. new block or RBF
+                    // keep the mempool until next update()
+                    warn!("failed to get transactions {:?}: {}", txids, err);
+                    let empty: HashSet<Sha256dHash> = HashSet::new();
+                    return Ok(empty);
                 }
             };
             for ((txid, entry), tx) in entries.into_iter().zip(txs.into_iter()) {
                 assert_eq!(tx.txid(), *txid);
                 self.add(txid, tx, entry);
             }
+            changed_txs = txids.iter().map(|txid| *txid.clone()).collect();
         }
         timer.observe_duration();
 
         let timer = self.stats.start_timer("remove");
         for txid in old_txids.difference(&new_txids) {
             self.remove(txid);
+            changed_txs.insert(txid.clone());
         }
         timer.observe_duration();
 
@@ -238,7 +246,7 @@ impl Tracker {
         timer.observe_duration();
 
         self.stats.count.set(self.items.len() as i64);
-        Ok(())
+        Ok(changed_txs)
     }
 
     fn add(&mut self, txid: &Sha256dHash, tx: Transaction, entry: MempoolEntry) {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,10 +2,11 @@ use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin_hashes::hex::{FromHex, ToHex};
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use bitcoin_hashes::Hash;
 use error_chain::ChainedError;
 use hex;
 use serde_json::{from_str, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc::{Sender, SyncSender};
@@ -13,8 +14,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::errors::*;
+use crate::index::compute_script_hash;
 use crate::metrics::{Gauge, HistogramOpts, HistogramVec, MetricOpts, Metrics};
 use crate::query::{Query, Status};
+use crate::util::FullHash;
 use crate::util::{spawn_thread, Channel, HeaderEntry, SyncChannel};
 
 const ELECTRSCASH_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -68,6 +71,17 @@ fn unspent_from_status(status: &Status) -> Value {
             }))
             .collect()
     ))
+}
+
+fn get_output_scripthash(txn: &Transaction, n: Option<usize>) -> Vec<FullHash> {
+    if let Some(out) = n {
+        vec![compute_script_hash(&txn.output[out].script_pubkey[..])]
+    } else {
+        txn.output
+            .iter()
+            .map(|o| compute_script_hash(&o.script_pubkey[..]))
+            .collect()
+    }
 }
 
 struct Connection {
@@ -215,6 +229,9 @@ impl Connection {
         let status = self.query.status(&script_hash[..])?;
         let result = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
         self.status_hashes.insert(script_hash, result.clone());
+        self.stats
+            .subscriptions
+            .set(self.status_hashes.len() as i64);
         Ok(result)
     }
 
@@ -249,10 +266,6 @@ impl Connection {
         let tx = hex::decode(&tx).chain_err(|| "non-hex tx")?;
         let tx: Transaction = deserialize(&tx).chain_err(|| "failed to parse tx")?;
         let txid = self.query.broadcast(&tx)?;
-        self.query.update_mempool()?;
-        if let Err(e) = self.chan.sender().try_send(Message::PeriodicUpdate) {
-            warn!("failed to issue PeriodicUpdate after broadcast: {}", e);
-        }
         Ok(json!(txid.to_hex()))
     }
 
@@ -354,42 +367,63 @@ impl Connection {
         })
     }
 
-    fn update_subscriptions(&mut self) -> Result<Vec<Value>> {
+    fn on_scripthash_change(&mut self, scripthash: FullHash) -> Result<()> {
+        let scripthash = Sha256dHash::from_slice(&scripthash[..]).expect("invalid scripthash");
+
+        let old_statushash;
+        match self.status_hashes.get(&scripthash) {
+            Some(statushash) => {
+                old_statushash = statushash;
+            }
+            None => {
+                return Ok(());
+            }
+        };
+
         let timer = self
             .stats
             .latency
-            .with_label_values(&["periodic_update"])
+            .with_label_values(&["statushash_update"])
             .start_timer();
-        let mut result = vec![];
-        if let Some(ref mut last_entry) = self.last_header_entry {
-            let entry = self.query.get_best_header()?;
-            if *last_entry != entry {
-                *last_entry = entry;
-                let hex_header = hex::encode(serialize(last_entry.header()));
-                let header = json!({"hex": hex_header, "height": last_entry.height()});
-                result.push(json!({
-                    "jsonrpc": "2.0",
-                    "method": "blockchain.headers.subscribe",
-                    "params": [header]}));
-            }
-        }
-        for (script_hash, status_hash) in self.status_hashes.iter_mut() {
-            let status = self.query.status(&script_hash[..])?;
-            let new_status_hash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
-            if new_status_hash == *status_hash {
-                continue;
-            }
-            result.push(json!({
-                "jsonrpc": "2.0",
-                "method": "blockchain.scripthash.subscribe",
-                "params": [script_hash.to_hex(), new_status_hash]}));
-            *status_hash = new_status_hash;
+
+        let status = self.query.status(&scripthash[..])?;
+        let new_statushash = status.hash().map_or(Value::Null, |h| json!(hex::encode(h)));
+        if new_statushash == *old_statushash {
+            return Ok(());
         }
         timer.observe_duration();
-        self.stats
-            .subscriptions
-            .set(self.status_hashes.len() as i64);
-        Ok(result)
+        self.send_values(&vec![json!({
+                    "jsonrpc": "2.0",
+                    "method": "blockchain.scripthash.subscribe",
+                    "params": [scripthash.to_hex(), new_statushash]})])?;
+        self.status_hashes.insert(scripthash, new_statushash);
+        Ok(())
+    }
+
+    fn on_chaintip_change(&mut self, chaintip: HeaderEntry) -> Result<()> {
+        let timer = self
+            .stats
+            .latency
+            .with_label_values(&["chaintip_update"])
+            .start_timer();
+
+        if let Some(ref mut last_entry) = self.last_header_entry {
+            if *last_entry == chaintip {
+                return Ok(());
+            }
+
+            *last_entry = chaintip;
+            let hex_header = hex::encode(serialize(last_entry.header()));
+            let header = json!({"hex": hex_header, "height": last_entry.height()});
+            self.send_values(&vec![
+                (json!({
+                "jsonrpc": "2.0",
+                "method": "blockchain.headers.subscribe",
+                "params": [header]})),
+            ])?;
+        }
+        timer.observe_duration();
+        Ok(())
     }
 
     fn send_values(&mut self, values: &[Value]) -> Result<()> {
@@ -406,9 +440,9 @@ impl Connection {
         let empty_params = json!([]);
         loop {
             let msg = self.chan.receiver().recv().chain_err(|| "channel closed")?;
-            trace!("RPC {:?}", msg);
             match msg {
                 Message::Request(line) => {
+                    trace!("RPC {:?}", line);
                     let cmd: Value = from_str(&line).chain_err(|| "invalid JSON format")?;
                     let reply = match (
                         cmd.get("method"),
@@ -424,12 +458,8 @@ impl Connection {
                     };
                     self.send_values(&[reply])?
                 }
-                Message::PeriodicUpdate => {
-                    let values = self
-                        .update_subscriptions()
-                        .chain_err(|| "failed to update subscriptions")?;
-                    self.send_values(&values)?
-                }
+                Message::ScriptHashChange(hash) => self.on_scripthash_change(hash)?,
+                Message::ChainTipChange(tip) => self.on_chaintip_change(tip)?,
                 Message::Done => return Ok(()),
             }
         }
@@ -485,18 +515,21 @@ impl Connection {
 #[derive(Debug)]
 pub enum Message {
     Request(String),
-    PeriodicUpdate,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Done,
 }
 
 pub enum Notification {
-    Periodic,
+    ScriptHashChange(FullHash),
+    ChainTipChange(HeaderEntry),
     Exit,
 }
 
 pub struct RPC {
     notification: Sender<Notification>,
     server: Option<thread::JoinHandle<()>>, // so we can join the server while dropping this ojbect
+    query: Arc<Query>,
 }
 
 struct Stats {
@@ -514,10 +547,17 @@ impl RPC {
             for msg in notification.receiver().iter() {
                 let senders = senders.lock().unwrap();
                 match msg {
-                    Notification::Periodic => {
+                    Notification::ScriptHashChange(hash) => {
                         for (i, sender) in senders.iter() {
-                            if let Err(e) = sender.try_send(Message::PeriodicUpdate) {
-                                warn!("failed to send PeriodicUpdate to peer {}: {}", i, e);
+                            if let Err(e) = sender.try_send(Message::ScriptHashChange(hash)) {
+                                warn!("failed to send ScriptHashChange to peer {}: {}", i, e);
+                            }
+                        }
+                    }
+                    Notification::ChainTipChange(hash) => {
+                        for (i, sender) in senders.iter() {
+                            if let Err(e) = sender.try_send(Message::ChainTipChange(hash.clone())) {
+                                warn!("failed to send ChainTipChange to peer {}: {}", i, e);
                             }
                         }
                     }
@@ -562,6 +602,7 @@ impl RPC {
         let notification = Channel::unbounded();
         RPC {
             notification: notification.sender(),
+            query: query.clone(),
             server: Some(spawn_thread("rpc", move || {
                 let senders = Arc::new(Mutex::new(HashMap::<i32, SyncSender<Message>>::new()));
                 let handles = Arc::new(Mutex::new(
@@ -629,8 +670,81 @@ impl RPC {
         }
     }
 
-    pub fn notify(&self) {
-        self.notification.send(Notification::Periodic).unwrap();
+    fn get_scripthashes_effected_by_tx(
+        &self,
+        txid: &Sha256dHash,
+        blockhash: Option<Sha256dHash>,
+    ) -> Result<Vec<FullHash>> {
+        let txn = self.query.load_txn_with_blockhashlookup(txid, blockhash)?;
+        let mut scripthashes = get_output_scripthash(&txn, None);
+
+        for txin in txn.input {
+            if txin.previous_output.is_null() {
+                continue;
+            }
+            let id: &Sha256dHash = &txin.previous_output.txid;
+            let n = txin.previous_output.vout as usize;
+
+            let txn = self.query.load_txn_with_blockhashlookup(&id, None)?;
+            scripthashes.extend(get_output_scripthash(&txn, Some(n)));
+        }
+        Ok(scripthashes)
+    }
+
+    pub fn notify_scripthash_subscriptions(
+        &self,
+        headers_changed: &Vec<HeaderEntry>,
+        txs_changed: HashSet<Sha256dHash>,
+    ) {
+        let mut txn_done: HashSet<Sha256dHash> = HashSet::new();
+        let mut scripthashes: HashSet<FullHash> = HashSet::new();
+
+        let mut insert_for_tx = |txid, blockhash| {
+            if !txn_done.insert(txid) {
+                return;
+            }
+            if let Ok(hashes) = self.get_scripthashes_effected_by_tx(&txid, blockhash) {
+                for h in hashes {
+                    scripthashes.insert(h);
+                }
+            } else {
+                trace!("failed to get effected scripthashes for tx {}", txid);
+            }
+        };
+
+        for header in headers_changed {
+            let blockhash = header.hash();
+            let txids = match self.query.getblocktxids(&blockhash) {
+                Ok(txids) => txids,
+                Err(e) => {
+                    warn!("Failed to get blocktxids for {}: {}", blockhash, e);
+                    continue;
+                }
+            };
+            for txid in txids {
+                insert_for_tx(txid, Some(*blockhash));
+            }
+        }
+        for txid in txs_changed {
+            insert_for_tx(txid, None);
+        }
+
+        for s in scripthashes.drain() {
+            if let Err(e) = self.notification.send(Notification::ScriptHashChange(s)) {
+                trace!("Scripthash change notification failed: {}", e);
+            }
+        }
+    }
+
+    pub fn notify_subscriptions_chaintip(&self, header: HeaderEntry) {
+        if let Err(e) = self.notification.send(Notification::ChainTipChange(header)) {
+            trace!("Failed to notify about chaintip change {}", e);
+        }
+    }
+
+    pub fn disconnect_clients(&self) {
+        trace!("disconncting clients");
+        self.notification.send(Notification::Exit).unwrap();
     }
 }
 


### PR DESCRIPTION
This removes the expensive PeriodicUpdate call from application loop.

PeriodicUpdate would iterate through every subscription by every client
and re-calculate its status to look for differences.

The new code calculates which subscription need update and notifies each
RPC connection. If, and only if, a client is subscried will it
re-calculate its status.