### PR TITLE
Identify transactions with unconfirmed parents

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -178,7 +178,7 @@ pub fn index_transaction<'a>(
     let null_hash = Sha256dHash::default();
     let txid: Sha256dHash = txn.txid();
 
-    let cashaccount = index_cashaccount(txn, height);
+    let cashaccount = index_cashaccount(txn, height as u32);
 
     let inputs = txn.input.iter().filter_map(move |input| {
         if input.previous_output.txid == null_hash {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -315,7 +315,7 @@ impl Connection {
         let name = name.as_str().chain_err(|| "bad accountname")?;
         let height = usize_from_value(params.get(1), "height")?;
 
-        self.query.get_cashaccount_txs(name, height)
+        self.query.get_cashaccount_txs(name, height as u32)
     }
 
     fn handle_command(&mut self, method: &str, params: &[Value], id: &Value) -> Result<Value> {


### PR DESCRIPTION
As is the spec for `get_history`.

Fixes #27 