### PR TITLE
RPC call blockchain.scripthash.get_first_use

### DIFF
--- a/examples/blockchain_scripthash_get_first_use.py
+++ b/examples/blockchain_scripthash_get_first_use.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import bitcoincash
+
+from bitcoincash.electrum import Electrum
+from bitcoincash.electrum.svr_info import ServerInfo
+from bitcoincash.core import CBlockHeader, x
+from bitcoincash.wallet import CBitcoinAddress
+import asyncio
+
+bitcoincash.SelectParams("testnet")
+scripthash = CBitcoinAddress("bchtest:qq2ckhgcz4fvna8jvlqdu692ujtrqsue8yarpm648v").to_scriptHash()
+
+async def electrum_stuff():
+    cli = Electrum()
+
+    await cli.connect(ServerInfo("localhost", hostname="localhost", ports=["t60001"]))
+
+    print(await cli.RPC('blockchain.scripthash.get_first_use', scripthash))
+
+    await cli.close()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(electrum_stuff())
+loop.close()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ pub enum RpcErrorCode {
     InvalidParams = -32602,
     InternalError = -32603,
     Other = -32000, /* Range -32000 to -32099 is serve defined */
+    NotFound = -32004,
 }
 
 error_chain! {


### PR DESCRIPTION
Implements new RPC call blockchain.scripthash.get_firstuse. This RPC
calls returns the hash of the first block scripthash was found in.

It returns a hash of all the transaction that have scripthash as output
in that block.

Note: Does not return transaction spending scripthash as input. Use
get_history for that.

Output from example script:
```
$ ./blockchain_scripthash_get_firstuse.py 
{'block_hash': '000000000000007f6c0e53f4560e15e1a805470144c00e1d81b78543e69c59c4', 'tx_hash': ['491aa3f7fd1f23882c3437898125259d2a0c044bea0f6aa659b8d7d6ab75632a']}
```