### PR TITLE
Return error on unknown method

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,13 @@
+#[derive(Debug, Copy, Clone)]
+pub enum RpcErrorCode {
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    Other = -32000, /* Range -32000 to -32099 is serve defined */
+}
+
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
@@ -12,6 +22,11 @@ error_chain! {
         Interrupt(sig: i32) {
             description("Interruption by external signal")
             display("Interrupted by signal {}", sig)
+        }
+
+        RpcError(code: RpcErrorCode, msg: String) {
+            description("RPC error")
+            display("RPC error ({} {:?}): {}", *code as i32, code, msg)
         }
     }
 }


### PR DESCRIPTION
Don't disconnect the client, return proper error instead. Fixes #25.