### PR TITLE
Use cache for blockchain.transaction.get 

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -132,11 +132,8 @@ impl TransactionCache {
     where
         F: FnOnce() -> Result<Vec<u8>>,
     {
-        match self.map.lock().unwrap().get(txid) {
-            Some(serialized_txn) => {
-                return Ok(deserialize(&serialized_txn).chain_err(|| "failed to parse cached tx")?);
-            }
-            None => {}
+        if let Some(txn) = self.get(txid) {
+            return Ok(txn);
         }
         let serialized_txn = load_txn_func()?;
         let txn = deserialize(&serialized_txn).chain_err(|| "failed to parse serialized tx")?;
@@ -146,6 +143,18 @@ impl TransactionCache {
             .unwrap()
             .put(*txid, serialized_txn, byte_size);
         Ok(txn)
+    }
+
+    pub fn get(&self, txid: &Sha256dHash) -> Option<Transaction> {
+        if let Some(serialized_txn) = self.map.lock().unwrap().get(txid) {
+            if let Ok(tx) = deserialize(&serialized_txn) {
+                return Some(tx);
+            }
+            else {
+                trace!("failed to parse cached tx");
+            }
+        }
+        None
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -149,9 +149,8 @@ impl TransactionCache {
         if let Some(serialized_txn) = self.map.lock().unwrap().get(txid) {
             if let Ok(tx) = deserialize(&serialized_txn) {
                 return Some(tx);
-            }
-            else {
-                trace!("failed to parse cached tx");
+            } else {
+                trace!("failed to parse a cached tx");
             }
         }
         None

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -535,7 +535,7 @@ impl Daemon {
     pub fn gettransaction_raw(
         &self,
         txhash: &Sha256dHash,
-        blockhash: Option<Sha256dHash>,
+        blockhash: Option<&Sha256dHash>,
         verbose: bool,
     ) -> Result<Value> {
         let mut args = json!([txhash.to_hex(), verbose]);


### PR DESCRIPTION
Avoids call to bitcoind, and also puts the transaction into our cache.

Produces verbose output without help from bitcoind.

Tests added here: https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/2076