### PR TITLE
Upstream changes

### DIFF
--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -60,14 +60,17 @@ fn run_server(config: &Config) -> Result<()> {
     let app = App::new(store, index, daemon, &config)?;
     let tx_cache = TransactionCache::new(config.tx_cache_size, &metrics);
     let query = Query::new(app.clone(), &metrics, tx_cache, config.txid_limit);
+    let relayfee = query.get_relayfee()?;
+    debug!("relayfee: {} BTC", relayfee);
 
     let mut server = None; // Electrum RPC server
 
     loop {
         let (headers_changed, new_tip) = app.update(&signal)?;
         let txs_changed = query.update_mempool()?;
-        let rpc = server
-            .get_or_insert_with(|| RPC::start(config.electrum_rpc_addr, query.clone(), &metrics));
+        let rpc = server.get_or_insert_with(|| {
+            RPC::start(config.electrum_rpc_addr, query.clone(), &metrics, relayfee)
+        });
         rpc.notify_scripthash_subscriptions(&headers_changed, txs_changed);
         if let Some(header) = new_tip {
             rpc.notify_subscriptions_chaintip(header);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -113,6 +113,7 @@ struct BlockchainInfo {
 struct NetworkInfo {
     version: u64,
     subversion: String,
+    relayfee: f64, // in BTC
 }
 
 pub struct MempoolEntry {
@@ -456,6 +457,10 @@ impl Daemon {
 
     pub fn get_subversion(&self) -> Result<String> {
         Ok(self.getnetworkinfo()?.subversion)
+    }
+
+    pub fn get_relayfee(&self) -> Result<f64> {
+        Ok(self.getnetworkinfo()?.relayfee)
     }
 
     pub fn getbestblockhash(&self) -> Result<Sha256dHash> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -650,7 +650,7 @@ impl Query {
     }
 
     // Fee rate [BTC/kB] to be confirmed in `blocks` from now.
-    pub fn estimate_fee(&self, blocks: usize) -> f32 {
+    pub fn estimate_fee(&self, blocks: usize) -> f64 {
         let mut total_vsize = 0u32;
         let mut last_fee_rate = 0.0;
         let blocks_in_vbytes = (blocks * 1_000_000) as u32; // assume ~1MB blocks
@@ -661,7 +661,7 @@ impl Query {
                 break; // under-estimate the fee rate a bit
             }
         }
-        last_fee_rate * 1e-5 // [BTC/kB] = 10^5 [sat/B]
+        (last_fee_rate as f64) * 1e-5 // [BTC/kB] = 10^5 [sat/B]
     }
 
     pub fn get_banner(&self) -> Result<String> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -740,4 +740,8 @@ impl Query {
         let tracker = self.tracker.read().unwrap();
         get_tx(tracker.index())
     }
+
+    pub fn get_relayfee(&self) -> Result<f64> {
+        self.app.daemon().get_relayfee()
+    }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -679,14 +679,14 @@ impl RPC {
                     Notification::ScriptHashChange(hash) => {
                         for (i, sender) in senders.iter() {
                             if let Err(e) = sender.try_send(Message::ScriptHashChange(hash)) {
-                                warn!("failed to send ScriptHashChange to peer {}: {}", i, e);
+                                debug!("failed to send ScriptHashChange to peer {}: {}", i, e);
                             }
                         }
                     }
                     Notification::ChainTipChange(hash) => {
                         for (i, sender) in senders.iter() {
                             if let Err(e) = sender.try_send(Message::ChainTipChange(hash.clone())) {
-                                warn!("failed to send ChainTipChange to peer {}: {}", i, e);
+                                debug!("failed to send ChainTipChange to peer {}: {}", i, e);
                             }
                         }
                     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -233,11 +233,11 @@ impl Connection {
     fn blockchain_estimatefee(&self, params: &[Value]) -> Result<Value> {
         let blocks_count = usize_from_value(params.get(0), "blocks_count")?;
         let fee_rate = self.query.estimate_fee(blocks_count); // in BTC/kB
-        Ok(json!(fee_rate))
+        Ok(json!(fee_rate.max(self.relayfee)))
     }
 
     fn blockchain_relayfee(&self) -> Result<Value> {
-        Ok(json!(self.relayfee))
+        Ok(json!(self.relayfee)) // in BTC/kB
     }
 
     fn blockchain_scripthash_subscribe(&mut self, params: &[Value]) -> Result<Value> {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -104,6 +104,7 @@ struct Connection {
     addr: SocketAddr,
     chan: SyncChannel<Message>,
     stats: Arc<Stats>,
+    relayfee: f64,
 }
 
 impl Connection {
@@ -112,6 +113,7 @@ impl Connection {
         stream: TcpStream,
         addr: SocketAddr,
         stats: Arc<Stats>,
+        relayfee: f64,
     ) -> Connection {
         Connection {
             query,
@@ -121,6 +123,7 @@ impl Connection {
             addr,
             chan: SyncChannel::new(10),
             stats,
+            relayfee,
         }
     }
 
@@ -234,7 +237,7 @@ impl Connection {
     }
 
     fn blockchain_relayfee(&self) -> Result<Value> {
-        Ok(json!(0.0)) // allow sending transactions with any fee.
+        Ok(json!(self.relayfee))
     }
 
     fn blockchain_scripthash_subscribe(&mut self, params: &[Value]) -> Result<Value> {
@@ -717,7 +720,7 @@ impl RPC {
         chan
     }
 
-    pub fn start(addr: SocketAddr, query: Arc<Query>, metrics: &Metrics) -> RPC {
+    pub fn start(addr: SocketAddr, query: Arc<Query>, metrics: &Metrics, relayfee: f64) -> RPC {
         let stats = Arc::new(Stats {
             latency: metrics.histogram_vec(
                 HistogramOpts::new("electrscash_electrum_rpc", "Electrum RPC latency (seconds)"),
@@ -755,7 +758,7 @@ impl RPC {
 
                         spawn_thread("peer", move || {
                             info!("[{}] connected peer #{}", addr, handle_id);
-                            let conn = Connection::new(query, stream, addr, stats);
+                            let conn = Connection::new(query, stream, addr, stats, relayfee);
                             senders
                                 .lock()
                                 .unwrap()


### PR DESCRIPTION
* Use relay fee from `bitcoind` instead of hard coded value
* Don't warn on failing to notify peer