### PR TITLE
Add RPC timeout

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -111,3 +111,9 @@ name = "server_banner"
 type = "String"
 doc = "The banner to be shown in the Electrum console"
 default = "concat!(\"Welcome to ElectrsCash \", env!(\"CARGO_PKG_VERSION\"), \" (Electrum Rust Server)!\").to_owned()"
+
+[[param]]
+name = "rpc_timeout"
+type = "usize"
+doc = "Maximum time in seconds an RPC call may make. Mitigates DoS when querying 'too popular' addresses"
+default = "10"

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -61,7 +61,8 @@ fn run_server(config: &Config) -> Result<()> {
     let tx_cache = TransactionCache::new(config.tx_cache_size, &metrics);
     let query = Query::new(app.clone(), &metrics, tx_cache, config.txid_limit);
     let relayfee = query.get_relayfee()?;
-    debug!("relayfee: {} BTC", relayfee);
+    debug!("relayfee: {}", relayfee);
+    let rpc_timeout = config.rpc_timeout;
 
     let mut server = None; // Electrum RPC server
 
@@ -69,7 +70,13 @@ fn run_server(config: &Config) -> Result<()> {
         let (headers_changed, new_tip) = app.update(&signal)?;
         let txs_changed = query.update_mempool()?;
         let rpc = server.get_or_insert_with(|| {
-            RPC::start(config.electrum_rpc_addr, query.clone(), &metrics, relayfee)
+            RPC::start(
+                config.electrum_rpc_addr,
+                query.clone(),
+                &metrics,
+                relayfee,
+                rpc_timeout,
+            )
         });
         rpc.notify_scripthash_subscriptions(&headers_changed, txs_changed);
         if let Some(header) = new_tip {

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,6 +138,7 @@ pub struct Config {
     pub server_banner: String,
     pub blocktxids_cache_size: usize,
     pub cookie_getter: Arc<dyn CookieGetter>,
+    pub rpc_timeout: u16,
 }
 
 /// Returns default daemon directory
@@ -269,6 +270,7 @@ impl Config {
             txid_limit: config.txid_limit,
             server_banner: config.server_banner,
             cookie_getter,
+            rpc_timeout: config.rpc_timeout as u16,
         };
         eprintln!("{:?}", config);
         config

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,6 +7,7 @@ pub enum RpcErrorCode {
     InternalError = -32603,
     Other = -32000, /* Range -32000 to -32099 is serve defined */
     NotFound = -32004,
+    Timeout = -32005,
 }
 
 error_chain! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,5 @@ pub mod query;
 pub mod rpc;
 pub mod signal;
 pub mod store;
+pub mod timeout;
 pub mod util;

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,37 @@
+use crate::errors::*;
+use std::time::{Duration, Instant};
+
+struct TimeoutTrigger {
+    start: Instant,
+    timeout: Duration,
+}
+
+impl TimeoutTrigger {
+    pub fn new(timeout: Duration) -> TimeoutTrigger {
+        TimeoutTrigger {
+            start: Instant::now(),
+            timeout: timeout,
+        }
+    }
+
+    pub fn check(&self) -> Result<()> {
+        if self.start.elapsed() >= self.timeout {
+            return Err("Timeout".into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_timeout() {
+        let timeout = TimeoutTrigger::new(Duration::from_millis(50));
+        assert!(!timeout.check().is_err());
+        sleep(Duration::from_millis(50));
+        assert!(timeout.check().is_err());
+    }
+}

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use std::time::{Duration, Instant};
 
-struct TimeoutTrigger {
+pub struct TimeoutTrigger {
     start: Instant,
     timeout: Duration,
 }
@@ -16,7 +16,7 @@ impl TimeoutTrigger {
 
     pub fn check(&self) -> Result<()> {
         if self.start.elapsed() >= self.timeout {
-            return Err("Timeout".into());
+            return Err(ErrorKind::RpcError(RpcErrorCode::Timeout, "Timeout".into()).into());
         }
         Ok(())
     }


### PR DESCRIPTION
Add timeout checks to the most expensive RPC calls.

Timeout can be configured with a new option --rcp-timeout.

Closes #43 