### PR TITLE
Add config option to indicate low memory

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -112,8 +112,14 @@ type = "String"
 doc = "The banner to be shown in the Electrum console"
 default = "concat!(\"Welcome to ElectrsCash \", env!(\"CARGO_PKG_VERSION\"), \" (Electrum Rust Server)!\").to_owned()"
 
+
 [[param]]
 name = "rpc_timeout"
 type = "usize"
 doc = "Maximum time in seconds an RPC call may make. Mitigates DoS when querying 'too popular' addresses"
 default = "10"
+
+[[switch]]
+name = "low_memory"
+doc = "Indicate preference to less memory usage over performance"
+default = false

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -40,7 +40,7 @@ fn run_server(config: &Config) -> Result<()> {
         &metrics,
     )?;
     // Perform initial indexing from local blk*.dat block files.
-    let store = DBStore::open(&config.db_path, /*low_memory=*/ config.jsonrpc_import);
+    let store = DBStore::open(&config.db_path, config.low_memory);
     let index = Index::load(&store, &daemon, &metrics, config.index_batch_size)?;
     let store = if is_fully_compacted(&store) {
         store // initial import and full compaction are over

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,7 @@ pub struct Config {
     pub blocktxids_cache_size: usize,
     pub cookie_getter: Arc<dyn CookieGetter>,
     pub rpc_timeout: u16,
+    pub low_memory: bool,
 }
 
 /// Returns default daemon directory
@@ -271,6 +272,7 @@ impl Config {
             server_banner: config.server_banner,
             cookie_getter,
             rpc_timeout: config.rpc_timeout as u16,
+            low_memory: config.low_memory,
         };
         eprintln!("{:?}", config);
         config
@@ -311,6 +313,8 @@ debug_struct! { Config,
     txid_limit,
     server_banner,
     blocktxids_cache_size,
+    rpc_timeout,
+    low_memory,
 }
 
 struct StaticCookie {


### PR DESCRIPTION
Fixes issue where using RPC interface implies low memory preference.