### PR TITLE
Start cashaccount indexing at activation height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,6 @@ dependencies = [
  "prometheus 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ time = "0.1"
 tiny_http = "0.6"
 unsigned-varint = "0.2.3"
 cashaccount-sys = ">=0.1"
-scopeguard = "1.0"
 c_fixed_string = "0.2"
 
 [build-dependencies]

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -123,3 +123,9 @@ default = "10"
 name = "low_memory"
 doc = "Indicate preference to less memory usage over performance"
 default = false
+
+[[param]]
+name = "cashaccount_activation_height"
+type = "usize"
+doc = "The activation blockheight for cashaccount. Set to 0 to disable cashaccount indexing"
+default = "563720"

--- a/examples/index.rs
+++ b/examples/index.rs
@@ -29,7 +29,7 @@ fn run() -> Result<()> {
         &metrics,
     )?;
     let fake_store = FakeStore {};
-    let index = Index::load(&fake_store, &daemon, &metrics, config.index_batch_size)?;
+    let index = Index::load(&fake_store, &daemon, &metrics, config.index_batch_size, 0)?;
     index.update(&fake_store, &signal)?;
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,6 +140,7 @@ pub struct Config {
     pub cookie_getter: Arc<dyn CookieGetter>,
     pub rpc_timeout: u16,
     pub low_memory: bool,
+    pub cashaccount_activation_height: u32,
 }
 
 /// Returns default daemon directory
@@ -273,6 +274,7 @@ impl Config {
             cookie_getter,
             rpc_timeout: config.rpc_timeout as u16,
             low_memory: config.low_memory,
+            cashaccount_activation_height: config.cashaccount_activation_height as u32,
         };
         eprintln!("{:?}", config);
         config
@@ -315,6 +317,7 @@ debug_struct! { Config,
     blocktxids_cache_size,
     rpc_timeout,
     low_memory,
+    cashaccount_activation_height,
 }
 
 struct StaticCookie {

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -32,7 +32,7 @@ impl MempoolStore {
     }
 
     fn add(&mut self, tx: &Transaction) {
-        let rows = index_transaction(tx, MEMPOOL_HEIGHT as usize);
+        let rows = index_transaction(tx, MEMPOOL_HEIGHT as usize, None);
         for row in rows {
             let (key, value) = row.into_pair();
             self.map.entry(key).or_insert_with(|| vec![]).push(value);
@@ -40,7 +40,7 @@ impl MempoolStore {
     }
 
     fn remove(&mut self, tx: &Transaction) {
-        let rows = index_transaction(tx, MEMPOOL_HEIGHT as usize);
+        let rows = index_transaction(tx, MEMPOOL_HEIGHT as usize, None);
         for row in rows {
             let (key, value) = row.into_pair();
             let no_values_left = {

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::app::App;
 use crate::cache::TransactionCache;
-use crate::cashaccount::{has_cashaccount, txids_by_cashaccount};
+use crate::cashaccount::{txids_by_cashaccount, CashAccountParser};
 use crate::errors::*;
 use crate::index::{compute_script_hash, TxInRow, TxOutRow, TxRow};
 use crate::mempool::{Tracker, MEMPOOL_HEIGHT};
@@ -685,9 +685,10 @@ impl Query {
         )?;
 
         // filter on name in case of txid prefix collision
+        let parser = CashAccountParser::new(None);
         let cashaccount_txns = cashaccount_txns
             .iter()
-            .filter(|txn| has_cashaccount(&txn.txn, name));
+            .filter(|txn| parser.has_cashaccount(&txn.txn, name));
 
         #[derive(Serialize, Deserialize, Debug)]
         struct AccountTx {


### PR DESCRIPTION
Don't index cashaccounts below cashaccount activation height. New
parameter --cashaccount-activation-height is added, which defaults to
activation on BCH.

Now that the piping is in place, a optimization to reuse allocated data
structure for parsing could also be added.

Closes #11 