### PR TITLE
Partial blockchain.address.* implementations

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -21,7 +21,7 @@ use crate::store::{ReadStore, Row};
 use crate::timeout::TimeoutTrigger;
 use crate::util::{hash_prefix, HashPrefix, HeaderEntry};
 
-enum ConfirmationState {
+pub enum ConfirmationState {
     Confirmed,
     InMempool,
     UnconfirmedParent,
@@ -32,7 +32,7 @@ pub struct FundingOutput {
     pub height: u32,
     pub output_index: usize,
     pub value: u64,
-    state: ConfirmationState,
+    pub state: ConfirmationState,
 }
 
 type OutPoint = (Sha256dHash, usize); // (txid, output_index)

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -26,6 +26,7 @@ use crate::util::{spawn_thread, Channel, HeaderEntry, SyncChannel};
 
 pub mod blockchain;
 pub mod parseutil;
+pub mod scripthash;
 pub mod server;
 
 fn get_output_scripthash(txn: &Transaction, n: Option<usize>) -> Vec<FullHash> {
@@ -91,6 +92,16 @@ impl Connection {
             .start_timer();
         let timeout = TimeoutTrigger::new(Duration::from_secs(self.rpc_timeout as u64));
         let result = match method {
+            "blockchain.address.get_balance" => {
+                self.blockchainrpc.address_get_balance(&params, &timeout)
+            }
+            "blockchain.address.get_first_use" => self.blockchainrpc.address_get_first_use(&params),
+            "blockchain.address.get_history" => {
+                self.blockchainrpc.address_get_history(&params, &timeout)
+            }
+            "blockchain.address.listunspent" => {
+                self.blockchainrpc.address_listunspent(&params, &timeout)
+            }
             "blockchain.block.header" => self.blockchainrpc.block_header(&params),
             "blockchain.block.headers" => self.blockchainrpc.block_headers(&params),
             "blockchain.estimatefee" => self.blockchainrpc.estimatefee(&params),

--- a/src/rpc/scripthash.rs
+++ b/src/rpc/scripthash.rs
@@ -1,0 +1,137 @@
+use crate::errors::*;
+use crate::mempool::MEMPOOL_HEIGHT;
+use crate::query::FundingOutput;
+use crate::query::{Query, Status};
+use crate::scripthash::{FullHash, ToLEHex};
+use crate::timeout::TimeoutTrigger;
+use bitcoin_hashes::hex::ToHex;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+use serde_json::Value;
+
+fn unspent_to_json(out: &FundingOutput) -> Value {
+    json!({
+        "height": if out.height == MEMPOOL_HEIGHT { 0 } else { out.height },
+        "tx_pos": out.output_index,
+        "tx_hash": out.txn_id.to_hex(),
+        "value": out.value,
+    })
+}
+
+fn unspent_from_status(status: &Status) -> Value {
+    json!(Value::Array(
+        status
+            .unspent()
+            .into_iter()
+            .map(|out| unspent_to_json(out))
+            .collect()
+    ))
+}
+
+pub fn get_balance(
+    query: &Query,
+    scripthash: &FullHash,
+    timeout: &TimeoutTrigger,
+) -> Result<Value> {
+    let status = query.status(&scripthash, timeout)?;
+    Ok(json!({
+        "confirmed": status.confirmed_balance(),
+        "unconfirmed": status.mempool_balance()
+    }))
+}
+
+pub fn get_first_use(query: &Query, scripthash: &FullHash) -> Result<Value> {
+    let firstuse = query.scripthash_first_use(scripthash)?;
+    if firstuse.0 == 0 {
+        return Err(ErrorKind::RpcError(
+            RpcErrorCode::NotFound,
+            format!("scripthash '{}' not found", scripthash.to_le_hex()),
+        )
+        .into());
+    }
+    let hash = if firstuse.0 == MEMPOOL_HEIGHT {
+        Sha256dHash::default()
+    } else {
+        let h = query.get_headers(&[firstuse.0 as usize]);
+        if h.is_empty() {
+            warn!("expected to find header for height {}", firstuse.0);
+            Sha256dHash::default()
+        } else {
+            *h[0].hash()
+        }
+    };
+
+    Ok(json!({
+        "block_hash": hash.to_hex(),
+        "block_height": if firstuse.0 == MEMPOOL_HEIGHT { 0 } else { firstuse.0 },
+        "tx_hash": firstuse.1.to_hex()
+    }))
+}
+pub fn get_history(
+    query: &Query,
+    scripthash: &FullHash,
+    timeout: &TimeoutTrigger,
+) -> Result<Value> {
+    let status = query.status(&scripthash, timeout)?;
+    Ok(json!(Value::Array(
+        status
+            .history()
+            .into_iter()
+            .map(|item| json!({"height": item.0, "tx_hash": item.1.to_hex()}))
+            .collect()
+    )))
+}
+
+pub fn listunspent(
+    query: &Query,
+    scripthash: &FullHash,
+    timeout: &TimeoutTrigger,
+) -> Result<Value> {
+    Ok(unspent_from_status(&query.status(scripthash, timeout)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::ConfirmationState;
+    use bitcoin_hashes::hex::FromHex;
+    use serde_json::from_str;
+
+    #[derive(Serialize, Deserialize)]
+    struct Unspent {
+        height: u32,
+        tx_pos: u32,
+        tx_hash: String,
+        value: u64,
+    }
+
+    fn create_out(height: u32, txn_id: Sha256dHash) -> FundingOutput {
+        FundingOutput {
+            txn_id: txn_id,
+            height: height,
+            output_index: 0,
+            value: 2020,
+            state: ConfirmationState::InMempool,
+        }
+    }
+
+    #[test]
+    fn test_output_to_json_mempool() {
+        // Mempool height is 0 in the json API
+        let out = create_out(MEMPOOL_HEIGHT, Sha256dHash::default());
+        let res: Unspent = from_str(&unspent_to_json(&out).to_string()).unwrap();
+        assert_eq!(0, res.height);
+
+        // Confirmed at block 5000
+        let out = create_out(5000, Sha256dHash::default());
+        let res: Unspent = from_str(&unspent_to_json(&out).to_string()).unwrap();
+        assert_eq!(5000, res.height);
+    }
+
+    #[test]
+    fn test_output_to_json_txid() {
+        let hex = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffff";
+        let out = create_out(1, Sha256dHash::from_hex(hex).unwrap());
+        let res: Unspent = from_str(&unspent_to_json(&out).to_string()).unwrap();
+        assert_eq!(hex, res.tx_hash);
+    }
+}


### PR DESCRIPTION
Adds:
- blockchain.address.get_balance
- blockchain.address.get_first_use
- blockchain.address.get_history
- blockchain.address.listunspent

Also fixes issue where listunspent would return wrong height for
unconfirmed transactions (with tests)