### PR TITLE
Remove calls to 'getblockhash'

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -481,11 +481,9 @@ impl Daemon {
     }
 
     pub fn getblockheaders(&self, heights: &[usize]) -> Result<Vec<BlockHeader>> {
-        let heights: Vec<Value> = heights.iter().map(|height| json!([height])).collect();
-        let params_list: Vec<Value> = self
-            .requests("getblockhash", &heights)?
+        let params_list: Vec<Value> = heights
             .into_iter()
-            .map(|hash| json!([hash, /*verbose=*/ false]))
+            .map(|height| json!([height.to_string(), /*verbose=*/ false]))
             .collect();
         let mut result = vec![];
         for h in self.requests("getblockheader", &params_list)? {


### PR DESCRIPTION
Both BU and BCHN have introduced in their API the possibility to call
getblockhash with _block height_ instead of _block hash_. Thus we don't need to call
getblockhash first.

Test plan:

./contrib/run_functional_tests.sh