### PR TITLE
[contrib] Add generic cli for calling RPC methods

### DIFF
--- a/contrib/client.py
+++ b/contrib/client.py
@@ -16,3 +16,23 @@ class Client:
         msg = json.dumps(req) + '\n'
         self.s.sendall(msg.encode('ascii'))
         return json.loads(self.f.readline())
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--port', action='store')
+    parser.add_argument('--server', action='store')
+    parser.add_argument('method')
+    parser.add_argument('args', nargs='*')
+    args = parser.parse_args()
+
+    port = 50001
+    if args.port:
+        port = args.port
+
+    server = "bitcoincash.network"
+    if args.server:
+        server = args.server
+
+    conn = Client((server, port))
+    print(conn.call(args.method, *args.args))


### PR DESCRIPTION
This adds a __main__ section to client.py so it can be used to test any
RPC calls.

Test plan:
```
$ python3 client.py "server.ping"
{'id': 0, 'jsonrpc': '2.0', 'result': None}

$ python3 client.py "blockchain.address.get_first_use"
"bitcoincash:qqfc3lxxylme0w87c5j2wdmsqln6e844xcmsdssvzy"
{'id': 0, 'jsonrpc': '2.0', 'result': {'block_hash':
'000000000000000002a04f56505ef459e1edd21fb3725524116fdaedf3a4d0ab',
'block_height': 597843, 'tx_hash':
'cef9c1485f166e92adf0b5d42e4ad202e4f5f9e2e7a072d0a6864c61c2cd6fa0'}}

$ python3 client.py "blockchain.address.get_scripthash"
"bitcoincash:qqfc3lxxylme0w87c5j2wdmsqln6e844xcmsdssvzy"
--server=bch.imaginary.cash
{'id': 0, 'jsonrpc': '2.0', 'result':
'273139c9327743dccc1030fc8d009e63e41e147c6b0449913d2dea5b71eef230'}
```