### PR TITLE
rpc: Add call blockchain.transaction.get_confirmed_blockhash

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -1,0 +1,29 @@
+# RPC methods supported
+
+See the [Electrum Cash Protocol specification](https://bitcoincash.network/electrum/)
+for "offical" supported RPC methods.
+
+In addition, the following RPC methods are supported.
+
+## blockchain.address.get\_first\_use
+
+See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
+
+## blockchain.scripthash.get\_first\_use
+
+See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
+
+## blockchain.transaction.get\_confirmed\_blockhash
+
+Returns the blockhash of a block the transaction confirmed in. Returns error
+if transaction is not confirmed (or does not exist).
+
+Signature: `blockchain.transaction.get_confirmed_blockhash(txid)`
+
+* txid - Transaction ID
+
+### Example result
+```
+'block_hash': '000000000000000002a04f56505ef459e1edd21fb3725524116fdaedf3a4d0ab',
+'block_height': 597843,
+```

--- a/src/query.rs
+++ b/src/query.rs
@@ -598,7 +598,11 @@ impl Query {
         if header.is_none() {
             bail!("tx {} is unconfirmed or does not exist", tx_hash);
         }
-        Ok(json!({ "block_hash": header.unwrap().hash() }))
+        let header = header.unwrap();
+        Ok(json!({
+            "block_hash": header.hash(),
+            "block_height": header.height()
+        }))
     }
 
     pub fn get_headers(&self, heights: &[usize]) -> Vec<HeaderEntry> {

--- a/src/query.rs
+++ b/src/query.rs
@@ -593,6 +593,14 @@ impl Query {
         self.load_txn_from_bitcoind(txid, hash.as_ref())
     }
 
+    pub fn get_confirmed_blockhash(&self, tx_hash: &Txid) -> Result<Value> {
+        let header = self.lookup_blockheader(tx_hash, None)?;
+        if header.is_none() {
+            bail!("tx {} is unconfirmed or does not exist", tx_hash);
+        }
+        Ok(json!({ "block_hash": header.unwrap().hash() }))
+    }
+
     pub fn get_headers(&self, heights: &[usize]) -> Vec<HeaderEntry> {
         let _timer = self
             .duration

--- a/src/rpc/blockchain.rs
+++ b/src/rpc/blockchain.rs
@@ -278,6 +278,11 @@ impl BlockchainRPC {
         }
     }
 
+    pub fn transaction_get_confirmed_blockhash(&self, params: &[Value]) -> Result<Value> {
+        let tx_hash = hash_from_value(params.get(0)).chain_err(|| "bad tx_hash")?;
+        self.query.get_confirmed_blockhash(&tx_hash)
+    }
+
     pub fn transaction_get_merkle(&self, params: &[Value]) -> Result<Value> {
         let tx_hash = hash_from_value::<Txid>(params.get(0))?;
         let height = usize_from_value(params.get(1), "height")?;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -131,6 +131,9 @@ impl Connection {
             }
             "blockchain.transaction.broadcast" => self.blockchainrpc.transaction_broadcast(&params),
             "blockchain.transaction.get" => self.blockchainrpc.transaction_get(&params),
+            "blockchain.transaction.get_confirmed_blockhash" => self
+                .blockchainrpc
+                .transaction_get_confirmed_blockhash(&params),
             "blockchain.transaction.get_merkle" => {
                 self.blockchainrpc.transaction_get_merkle(&params)
             }


### PR DESCRIPTION
From upstream, extended with `block_height` as well.