### PR TITLE
Use prometheus imports

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -15,7 +15,7 @@ use crate::cashaccount::CashAccountParser;
 use crate::daemon::Daemon;
 use crate::errors::*;
 use crate::index::{index_block, last_indexed_block, read_indexed_blockhashes};
-use crate::metrics::{CounterVec, Histogram, HistogramOpts, HistogramVec, MetricOpts, Metrics};
+use crate::metrics::Metrics;
 use crate::signal::Waiter;
 use crate::store::{DBStore, Row, WriteStore};
 use crate::util::{spawn_thread, HeaderList, SyncChannel};
@@ -26,9 +26,9 @@ struct Parser {
     indexed_blockhashes: Mutex<HashSet<BlockHash>>,
     cashaccount_activation_height: u32,
     // metrics
-    duration: HistogramVec,
-    block_count: CounterVec,
-    bytes_read: Histogram,
+    duration: prometheus::HistogramVec,
+    block_count: prometheus::IntCounterVec,
+    bytes_read: prometheus::Histogram,
 }
 
 impl Parser {
@@ -44,21 +44,21 @@ impl Parser {
             indexed_blockhashes: Mutex::new(indexed_blockhashes),
             cashaccount_activation_height,
             duration: metrics.histogram_vec(
-                HistogramOpts::new(
+                prometheus::HistogramOpts::new(
                     "electrscash_parse_duration",
                     "blk*.dat parsing duration (in seconds)",
                 ),
                 &["step"],
             ),
-            block_count: metrics.counter_vec(
-                MetricOpts::new(
+            block_count: metrics.counter_int_vec(
+                prometheus::Opts::new(
                     "electrscash_parse_blocks",
                     "# of block parsed (from blk*.dat)",
                 ),
                 &["type"],
             ),
 
-            bytes_read: metrics.histogram(HistogramOpts::new(
+            bytes_read: metrics.histogram(prometheus::HistogramOpts::new(
                 "electrscash_parse_bytes_read",
                 "# of bytes read (from blk*.dat)",
             )),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use crate::cache::BlockTxIDsCache;
 use crate::errors::*;
-use crate::metrics::{HistogramOpts, HistogramVec, Metrics};
+use crate::metrics::Metrics;
 use crate::signal::Waiter;
 use crate::util::HeaderList;
 
@@ -292,8 +292,8 @@ pub struct Daemon {
     blocktxids_cache: Arc<BlockTxIDsCache>,
 
     // monitoring
-    latency: HistogramVec,
-    size: HistogramVec,
+    latency: prometheus::HistogramVec,
+    size: prometheus::HistogramVec,
 }
 
 impl Daemon {
@@ -321,7 +321,7 @@ impl Daemon {
             blocktxids_cache,
             signal: signal.clone(),
             latency: metrics.histogram_vec(
-                HistogramOpts::new(
+                prometheus::HistogramOpts::new(
                     "electrscash_daemon_rpc",
                     "Bitcoind RPC latency (in seconds)",
                 ),
@@ -329,7 +329,10 @@ impl Daemon {
             ),
             // TODO: use better buckets (e.g. 1 byte to 10MB).
             size: metrics.histogram_vec(
-                HistogramOpts::new("electrscash_daemon_bytes", "Bitcoind RPC size (in bytes)"),
+                prometheus::HistogramOpts::new(
+                    "electrscash_daemon_bytes",
+                    "Bitcoind RPC size (in bytes)",
+                ),
                 &["method", "dir"],
             ),
         };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,13 +1,12 @@
-use prometheus::{self, Encoder, IntGauge};
 use std::fs;
 use std::io;
 use std::net::SocketAddr;
 use std::thread;
 use std::time::Duration;
 
-pub use prometheus::{
-    GaugeVec, Histogram, HistogramOpts, HistogramTimer, HistogramVec, IntCounter as Counter,
-    IntCounterVec as CounterVec, IntGauge as Gauge, Opts as MetricOpts,
+use prometheus::{
+    self, Encoder, Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts,
 };
 
 use crate::errors::*;
@@ -26,32 +25,38 @@ impl Metrics {
         }
     }
 
-    pub fn counter(&self, opts: prometheus::Opts) -> Counter {
-        let c = Counter::with_opts(opts).unwrap();
+    pub fn counter_int(&self, opts: prometheus::Opts) -> IntCounter {
+        let c = IntCounter::with_opts(opts).unwrap();
         self.reg.register(Box::new(c.clone())).unwrap();
         c
     }
 
-    pub fn counter_vec(&self, opts: prometheus::Opts, labels: &[&str]) -> CounterVec {
-        let c = CounterVec::new(opts, labels).unwrap();
+    pub fn counter_int_vec(&self, opts: prometheus::Opts, labels: &[&str]) -> IntCounterVec {
+        let c = IntCounterVec::new(opts, labels).unwrap();
         self.reg.register(Box::new(c.clone())).unwrap();
         c
     }
 
-    pub fn gauge(&self, opts: prometheus::Opts) -> Gauge {
+    pub fn gauge_float(&self, opts: prometheus::Opts) -> Gauge {
         let g = Gauge::with_opts(opts).unwrap();
         self.reg.register(Box::new(g.clone())).unwrap();
         g
     }
 
-    pub fn gauge_vec(&self, opts: prometheus::Opts, labels: &[&str]) -> GaugeVec {
+    pub fn gauge_float_vec(&self, opts: prometheus::Opts, labels: &[&str]) -> GaugeVec {
         let g = GaugeVec::new(opts, labels).unwrap();
         self.reg.register(Box::new(g.clone())).unwrap();
         g
     }
 
+    pub fn gauge_int_vec(&self, opts: prometheus::Opts, labels: &[&str]) -> IntGaugeVec {
+        let g = IntGaugeVec::new(opts, labels).unwrap();
+        self.reg.register(Box::new(g.clone())).unwrap();
+        g
+    }
+
     pub fn gauge_int(&self, opts: prometheus::Opts) -> IntGauge {
-        let g = Gauge::with_opts(opts).unwrap();
+        let g = IntGauge::with_opts(opts).unwrap();
         self.reg.register(Box::new(g.clone())).unwrap();
         g
     }
@@ -130,18 +135,18 @@ fn parse_stats() -> Result<Stats> {
 }
 
 fn start_process_exporter(metrics: &Metrics) {
-    let rss = metrics.gauge(MetricOpts::new(
+    let rss = metrics.gauge_int(Opts::new(
         "electrscash_process_memory_rss",
         "Resident memory size [bytes]",
     ));
-    let cpu = metrics.gauge_vec(
-        MetricOpts::new(
+    let cpu = metrics.gauge_float_vec(
+        Opts::new(
             "electrscash_process_cpu_usage",
             "CPU usage by this process [seconds]",
         ),
         &["type"],
     );
-    let fds = metrics.gauge(MetricOpts::new(
+    let fds = metrics.gauge_int(Opts::new(
         "electrscash_process_open_fds",
         "# of file descriptors",
     ));

--- a/src/query.rs
+++ b/src/query.rs
@@ -16,7 +16,7 @@ use crate::cashaccount::{txids_by_cashaccount, CashAccountParser};
 use crate::errors::*;
 use crate::index::{TxInRow, TxOutRow, TxRow};
 use crate::mempool::{Tracker, MEMPOOL_HEIGHT};
-use crate::metrics::{HistogramOpts, HistogramVec, Metrics};
+use crate::metrics::Metrics;
 use crate::scripthash::{compute_script_hash, FullHash};
 use crate::store::{ReadStore, Row};
 use crate::timeout::TimeoutTrigger;
@@ -258,7 +258,7 @@ pub struct Query {
     tracker: RwLock<Tracker>,
     tx_cache: TransactionCache,
     txid_limit: usize,
-    duration: HistogramVec,
+    duration: prometheus::HistogramVec,
 }
 
 impl Query {
@@ -274,7 +274,10 @@ impl Query {
             tx_cache,
             txid_limit,
             duration: metrics.histogram_vec(
-                HistogramOpts::new("electrs_query_duration", "Request duration (in seconds)"),
+                prometheus::HistogramOpts::new(
+                    "electrscash_query_duration",
+                    "Request duration (in seconds)",
+                ),
                 &["type"],
             ),
         })

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use crate::def::PROTOCOL_VERSION_MAX;
 use crate::errors::*;
-use crate::metrics::{HistogramOpts, MetricOpts, Metrics};
+use crate::metrics::Metrics;
 use crate::query::Query;
 use crate::rpc::blockchain::BlockchainRPC;
 use crate::rpc::parseutil::usize_from_value;
@@ -381,10 +381,13 @@ impl RPC {
     ) -> RPC {
         let stats = Arc::new(RPCStats {
             latency: metrics.histogram_vec(
-                HistogramOpts::new("electrscash_electrum_rpc", "Electrum RPC latency (seconds)"),
+                prometheus::HistogramOpts::new(
+                    "electrscash_electrum_rpc",
+                    "Electrum RPC latency (seconds)",
+                ),
                 &["method"],
             ),
-            subscriptions: metrics.gauge(MetricOpts::new(
+            subscriptions: metrics.gauge_int(prometheus::Opts::new(
                 "electrscash_scripthash_subscriptions",
                 "# of scripthash subscriptions for node",
             )),

--- a/src/rpc/rpcstats.rs
+++ b/src/rpc/rpcstats.rs
@@ -1,6 +1,6 @@
-use crate::metrics::{Gauge, HistogramVec};
+use prometheus::{HistogramVec, IntGauge};
 
 pub struct RPCStats {
     pub latency: HistogramVec,
-    pub subscriptions: Gauge,
+    pub subscriptions: IntGauge,
 }


### PR DESCRIPTION
Don't re-export prometheus aliased datatypes.

The re-exports were inconsistent with prometheus. For instance,
prometheus::IntGauge was reexported as metric::Gauge, while
prometheus::Gauge as not exported and works with floats.

We don't plan on replacing prometheus, so to fix this, we just remove
this layer of abstraction.