### PR TITLE
Add scripthash subscription limit

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -146,3 +146,9 @@ name = "rpc_buffer_size"
 type = "usize"
 doc = "Size of the message queue for each peer. If set too small, subscription notifications may drop"
 default = "2000"
+
+[[param]]
+name = "scripthash_subscription_limit"
+type = "u32"
+doc = "The maximum number of scripthash subscriptions per connection"
+default = "150000"

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -14,6 +14,7 @@ use electrscash::{
     cache::{BlockTxIDsCache, TransactionCache},
     config::Config,
     daemon::Daemon,
+    doslimit::ConnectionLimits,
     errors::*,
     index::Index,
     metrics::Metrics,
@@ -87,7 +88,8 @@ fn run_server(config: &Config) -> Result<()> {
     let tx_cache = TransactionCache::new(config.tx_cache_size as u64, &*metrics);
     let query = Query::new(app.clone(), &*metrics, tx_cache);
     let relayfee = query.get_relayfee()?;
-    debug!("relayfee: {}", relayfee);
+    let doslimits =
+        ConnectionLimits::new(config.rpc_timeout, config.scripthash_subscription_limit, 0);
 
     let mut server: Option<RPC> = None; // Electrum RPC server
 
@@ -108,7 +110,7 @@ fn run_server(config: &Config) -> Result<()> {
                 query.clone(),
                 metrics.clone(),
                 relayfee,
-                config.rpc_timeout,
+                doslimits,
                 config.rpc_buffer_size,
             )),
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,7 @@ pub struct Config {
     pub low_memory: bool,
     pub cashaccount_activation_height: u32,
     pub rpc_buffer_size: usize,
+    pub scripthash_subscription_limit: u32,
 }
 
 /// Returns default daemon directory
@@ -288,6 +289,7 @@ impl Config {
             low_memory: config.low_memory,
             cashaccount_activation_height: config.cashaccount_activation_height as u32,
             rpc_buffer_size: config.rpc_buffer_size,
+            scripthash_subscription_limit: config.scripthash_subscription_limit,
         };
         eprintln!("{:?}", config);
         config
@@ -332,6 +334,7 @@ debug_struct! { Config,
     low_memory,
     cashaccount_activation_height,
     rpc_buffer_size,
+    scripthash_subscription_limit,
 }
 
 struct StaticCookie {

--- a/src/doslimit.rs
+++ b/src/doslimit.rs
@@ -1,0 +1,38 @@
+use crate::errors::*;
+
+/// DoS limits per connection
+#[derive(Clone, Copy)]
+pub struct ConnectionLimits {
+    /// Maximum execution time per RPC call (in seconds)
+    pub rpc_timeout: u16,
+
+    /// Maximum number of scripthash subscriptions per connection
+    pub max_subscriptions: u32,
+
+    /// TODO: Maximum number of bytes used to alias scripthash subscriptions.
+    /// (scripthash aliased by bitcoin cash address)
+    pub max_alias_bytes: u32,
+}
+
+/// Limits specific for a connecting peer.
+impl ConnectionLimits {
+    pub fn new(rpc_timeout: u16, max_subscriptions: u32, max_alias_bytes: u32) -> ConnectionLimits {
+        ConnectionLimits {
+            rpc_timeout,
+            max_subscriptions,
+            max_alias_bytes,
+        }
+    }
+
+    pub fn check_subscriptions(&self, num_subscriptions: usize) -> Result<()> {
+        if num_subscriptions <= self.max_subscriptions as usize {
+            return Ok(());
+        }
+
+        Err(rpc_invalid_request(format!(
+            "Scripthash subscriptions limit reached (max {})",
+            self.max_subscriptions
+        ))
+        .into())
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,3 +32,7 @@ error_chain! {
         }
     }
 }
+
+pub fn rpc_invalid_request(what: String) -> ErrorKind {
+    ErrorKind::RpcError(RpcErrorCode::InvalidRequest, what)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod cashaccount;
 pub mod config;
 pub mod daemon;
 pub mod def;
+pub mod doslimit;
 pub mod errors;
 pub mod fake;
 pub mod index;


### PR DESCRIPTION
This sets a limit on number of subscriptions per connection.

Test plan:

A RPC functional test has been added to Bitcoin Unlimited that covers this.

`./contrib/run_functional_tests.sh`