### PR TITLE
rpc: Implement blockchain.address.(un)subscribe

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -152,3 +152,9 @@ name = "scripthash_subscription_limit"
 type = "u32"
 doc = "The maximum number of scripthash subscriptions per connection"
 default = "150000"
+
+[[param]]
+name = "scripthash_alias_bytes_limit"
+type = "u32"
+doc = "The maximum number of bytes stored for scripthash aliases. A bitcoincash address alias is 54 bytes, making the default allow ~1800 blockchain.address subscriptions."
+default = "100000"

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -88,8 +88,11 @@ fn run_server(config: &Config) -> Result<()> {
     let tx_cache = TransactionCache::new(config.tx_cache_size as u64, &*metrics);
     let query = Query::new(app.clone(), &*metrics, tx_cache);
     let relayfee = query.get_relayfee()?;
-    let doslimits =
-        ConnectionLimits::new(config.rpc_timeout, config.scripthash_subscription_limit, 0);
+    let doslimits = ConnectionLimits::new(
+        config.rpc_timeout,
+        config.scripthash_subscription_limit,
+        config.scripthash_alias_bytes_limit,
+    );
 
     let mut server: Option<RPC> = None; // Electrum RPC server
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,7 @@ pub struct Config {
     pub cashaccount_activation_height: u32,
     pub rpc_buffer_size: usize,
     pub scripthash_subscription_limit: u32,
+    pub scripthash_alias_bytes_limit: u32,
 }
 
 /// Returns default daemon directory
@@ -290,6 +291,7 @@ impl Config {
             cashaccount_activation_height: config.cashaccount_activation_height as u32,
             rpc_buffer_size: config.rpc_buffer_size,
             scripthash_subscription_limit: config.scripthash_subscription_limit,
+            scripthash_alias_bytes_limit: config.scripthash_alias_bytes_limit,
         };
         eprintln!("{:?}", config);
         config
@@ -335,6 +337,7 @@ debug_struct! { Config,
     cashaccount_activation_height,
     rpc_buffer_size,
     scripthash_subscription_limit,
+    scripthash_alias_bytes_limit,
 }
 
 struct StaticCookie {

--- a/src/def.rs
+++ b/src/def.rs
@@ -1,5 +1,5 @@
 pub const ELECTRSCASH_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const PROTOCOL_VERSION_MIN: &str = "1.4";
-pub const PROTOCOL_VERSION_MAX: &str = "1.4.2";
+pub const PROTOCOL_VERSION_MAX: &str = "1.4.3";
 pub const PROTOCOL_HASH_FUNCTION: &str = "sha256";
 pub const DATABASE_VERSION: &str = "1.1";

--- a/src/doslimit.rs
+++ b/src/doslimit.rs
@@ -24,14 +24,27 @@ impl ConnectionLimits {
         }
     }
 
-    pub fn check_subscriptions(&self, num_subscriptions: usize) -> Result<()> {
-        if num_subscriptions <= self.max_subscriptions as usize {
+    pub fn check_subscriptions(&self, num_subscriptions: u32) -> Result<()> {
+        if num_subscriptions <= self.max_subscriptions as u32 {
             return Ok(());
         }
 
         Err(rpc_invalid_request(format!(
             "Scripthash subscriptions limit reached (max {})",
             self.max_subscriptions
+        ))
+        .into())
+    }
+
+    pub fn check_alias_usage(&self, bytes_used: usize) -> Result<()> {
+        if bytes_used <= self.max_alias_bytes as usize {
+            return Ok(());
+        }
+
+        Err(rpc_invalid_request(format!(
+            "Address/alias subscriptions limit reached (max {} bytes) \
+            Use scripthash subscriptions for more subscriptions or increase this limit.",
+            self.max_alias_bytes
         ))
         .into())
     }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -104,9 +104,13 @@ impl Connection {
             "blockchain.address.get_scripthash" => {
                 self.blockchainrpc.address_get_scripthash(&params)
             }
+            "blockchain.address.subscribe" => {
+                self.blockchainrpc.address_subscribe(&params, &timeout)
+            }
             "blockchain.address.listunspent" => {
                 self.blockchainrpc.address_listunspent(&params, &timeout)
             }
+            "blockchain.address.unsubscribe" => self.blockchainrpc.address_unsubscribe(&params),
             "blockchain.block.header" => self.blockchainrpc.block_header(&params),
             "blockchain.block.headers" => self.blockchainrpc.block_headers(&params),
             "blockchain.estimatefee" => self.blockchainrpc.estimatefee(&params),


### PR DESCRIPTION
Implements `blockchain.address.subscribe` and `blockchain.address.unsubscribe`.

New DoS limit has been added, which limits how many bytes we store of address data. Bytes is used instead of number of subscriptions, as addresses can vary in size, depending on prefix, length of encoded hash etc.

Test plan:

A functional test has been added to Bitcoin Unlimited that cover both the calls, as well as the new DoS limit.

`./contrib/run_functional_tests.sh`