### PR TITLE
Add WebSocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 
 [[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e82538bc65a25dbdff70e4c5439d52f068048ab97cdea0acd73f131594caa1"
+dependencies = [
+ "async-global-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "crossbeam-utils 0.8.0",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +291,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "bytecodec"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16ea882cfbd9aa6e8f999fed22662f4c8c0853d1d231edec276e0e1f5a802e7"
+dependencies = [
+ "byteorder",
+ "trackable",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +334,12 @@ checksum = "fe6833b1e1b632d1a4c167aa8dc2a78a774bd78e14bc14579505d209327b47cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo_toml"
@@ -293,6 +435,15 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -433,10 +584,13 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "electrscash"
 version = "3.0.0"
 dependencies = [
+ "async-std",
  "base64 0.10.1",
  "bincode",
  "bitcoincash",
  "bitcoincash-addr",
+ "bytecodec",
+ "byteorder",
  "c_fixed_string",
  "cashaccount-sys",
  "configure_me",
@@ -446,6 +600,7 @@ dependencies = [
  "error-chain",
  "glob",
  "hex",
+ "httpcodec",
  "indexmap",
  "jemalloc-ctl",
  "jemallocator",
@@ -515,6 +670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fmt2io"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +707,42 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6c079abfac3ab269e2927ec048dabc89d009ebfdda6b8ee86624f30c689658"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "gcc"
@@ -568,6 +774,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +806,16 @@ name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "httpcodec"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f49d64351430cabd543943b79d48aaf0bc95a41d9ccf5b8774c2cfd23422775"
+dependencies = [
+ "bytecodec",
+ "trackable",
+]
 
 [[package]]
 name = "humantime"
@@ -616,6 +845,15 @@ checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -657,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +911,15 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -762,6 +1018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +1079,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +1093,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parse_arg"
@@ -858,6 +1136,31 @@ name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1216,6 +1519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "spin"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1679,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "trackable"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11475c3c53b075360eac9794965822cb053996046545f91cf61d90e00b72efa5"
+dependencies = [
+ "trackable_derive",
+]
+
+[[package]]
+name = "trackable_derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcf0b9b2caa5f4804ef77aeee1b929629853d806117c48258f402b69737e65c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,6 +1806,91 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+dependencies = [
+ "bumpalo",
+ "lazy_static 1.4.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if 0.1.10",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "web-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ spec = "config_spec.toml"
 default = ["rocksdb/snappy", "rocksdb/lz4", "rocksdb/zstd", "rocksdb/zlib", "rocksdb/bzip2"]
 
 [dependencies]
+async-std = "1.7.0"
 base64 = "0.10"
 bincode = "1.0"
 bitcoincash = { version = "0.23", features = ["use-serde"] }
+bytecodec = "0.4.13"
+byteorder = "1"
 configure_me = "0.3.4"
 configure_me_codegen = "0.3.14"
 crossbeam-channel = "0.3"
@@ -29,6 +32,7 @@ dirs = "1.0"
 error-chain = "0.12"
 glob = "0.3"
 hex = "0.3"
+httpcodec = "0.2.3"
 jemallocator = "0.3.2"
 jemalloc-ctl = "0.3.3"
 libc = "0.2"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -68,6 +68,11 @@ type = "crate::config::ResolvAddr"
 doc = "Electrum server JSONRPC 'addr:port' to listen on (default: '127.0.0.1:50001' for mainnet, '127.0.0.1:60001' for testnet and '127.0.0.1:60401' for regtest)"
 
 [[param]]
+name = "electrum_ws_addr"
+type = "crate::config::ResolvAddr"
+doc = "Electrum websocket server 'addr:port' to listen on (default: '127.0.0.1:50003' for mainnet, '127.0.0.1:60003' for testnet and '127.0.0.1:60403' for regtest)"
+
+[[param]]
 name = "daemon_rpc_addr"
 type = "crate::config::ResolvAddr"
 doc = "Bitcoin daemon JSONRPC 'addr:port' to connect (default: 127.0.0.1:8332 for mainnet, 127.0.0.1:18332 for testnet and 127.0.0.1:18443 for regtest)"

--- a/contrib/websocket-client/cli.js
+++ b/contrib/websocket-client/cli.js
@@ -1,0 +1,30 @@
+const { ElectrumClient, ElectrumTransport } = require('electrum-cash');
+
+function guess_datatype (args) {
+    return args.map((a) => {
+        if (a.toLowerCase() == "true") {
+            return true;
+        }
+        if (a.toLowerCase() == "false") {
+            return false;
+        }
+        if (/^\d+$/.test(a)) {
+            return parseInt(a);
+        }
+        return a;
+    });
+}
+
+
+(async () => {
+    const electrum = new ElectrumClient('Test client',
+        '1.4.1', '127.0.0.1', ElectrumTransport.WS.Port, ElectrumTransport.WS.Scheme);
+
+    await electrum.connect();
+
+    const args = guess_datatype(process.argv.slice(2));
+    console.log(await electrum.request(...args));
+
+    electrum.disconnect();
+
+})().catch((e) => { console.error(e) });

--- a/contrib/websocket-client/package.json
+++ b/contrib/websocket-client/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "websocket-client",
+  "version": "1.0.0",
+  "description": "",
+  "main": "cli.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "electrum-cash": "^2.0.5"
+  }
+}

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -96,6 +96,12 @@ fn run_server(config: &Config) -> Result<()> {
 
     let mut server: Option<RPC> = None; // Electrum RPC server
 
+    let rpc_addr = config.electrum_rpc_addr;
+    let ws_addr = config.electrum_ws_addr;
+    electrscash::util::spawn_thread("ws", move || {
+        electrscash::wstcp::start_ws_proxy(ws_addr, rpc_addr)
+    });
+
     loop {
         let (headers_changed, new_tip) = app.update(&signal)?;
         let txs_changed = query.update_mempool()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,7 @@ pub struct Config {
     pub blocks_dir: PathBuf,
     pub daemon_rpc_addr: SocketAddr,
     pub electrum_rpc_addr: SocketAddr,
+    pub electrum_ws_addr: SocketAddr,
     pub monitoring_addr: SocketAddr,
     pub jsonrpc_import: bool,
     pub wait_duration: Duration,
@@ -220,12 +221,22 @@ impl Config {
             Network::Regtest => 24224,
         };
 
+        let default_ws_port = match config.network {
+            Network::Bitcoin => 50003,
+            Network::Testnet => 60003,
+            Network::Regtest => 60403,
+        };
+
         let daemon_rpc_addr: SocketAddr = config.daemon_rpc_addr.map_or(
             (DEFAULT_SERVER_ADDRESS, default_daemon_port).into(),
             ResolvAddr::resolve_or_exit,
         );
         let electrum_rpc_addr: SocketAddr = config.electrum_rpc_addr.map_or(
             (DEFAULT_SERVER_ADDRESS, default_electrum_port).into(),
+            ResolvAddr::resolve_or_exit,
+        );
+        let electrum_ws_addr: SocketAddr = config.electrum_ws_addr.map_or(
+            (DEFAULT_SERVER_ADDRESS, default_ws_port).into(),
             ResolvAddr::resolve_or_exit,
         );
         let monitoring_addr: SocketAddr = config.monitoring_addr.map_or(
@@ -277,6 +288,7 @@ impl Config {
             blocks_dir,
             daemon_rpc_addr,
             electrum_rpc_addr,
+            electrum_ws_addr,
             monitoring_addr,
             jsonrpc_import: config.jsonrpc_import,
             wait_duration: Duration::from_secs(config.wait_duration_secs),
@@ -325,6 +337,7 @@ debug_struct! { Config,
     blocks_dir,
     daemon_rpc_addr,
     electrum_rpc_addr,
+    electrum_ws_addr,
     monitoring_addr,
     jsonrpc_import,
     index_batch_size,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,11 @@ error_chain! {
             description("RPC error")
             display("RPC error ({} {:?}): {}", *code as i32, code, msg)
         }
+
+        WebSocket(msg: String) {
+            description("WebSocket error")
+            display("WebSocket {}", msg)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,4 @@ pub mod signal;
 pub mod store;
 pub mod timeout;
 pub mod util;
+pub mod wstcp;

--- a/src/wstcp/LICENSE
+++ b/src/wstcp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2018 Takeru Ohta <phjgt308@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/wstcp/channel.rs
+++ b/src/wstcp/channel.rs
@@ -1,0 +1,496 @@
+use crate::frame::{Frame, FrameDecoder, FrameEncoder};
+use crate::util::{self, WebSocketKey};
+use crate::{Error, ErrorKind, Result};
+use async_std::net::TcpStream;
+use bytecodec::io::{IoDecodeExt, IoEncodeExt, ReadBuf, StreamState, WriteBuf};
+use bytecodec::{Decode, Encode, EncodeExt};
+use httpcodec::{
+    HeaderField, HttpVersion, NoBodyDecoder, NoBodyEncoder, ReasonPhrase, Request, RequestDecoder,
+    Response, ResponseEncoder, StatusCode,
+};
+use slog::Logger;
+use std::future::Future;
+use std::mem;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+const BUF_SIZE: usize = 4096;
+
+#[derive(Debug)]
+pub struct ProxyChannel {
+    logger: Logger,
+    ws_stream: TcpStream,
+    ws_rbuf: ReadBuf<Vec<u8>>,
+    ws_wbuf: WriteBuf<Vec<u8>>,
+    real_server_addr: SocketAddr,
+    real_stream: Option<TcpStream>,
+    real_stream_rstate: StreamState,
+    real_stream_wstate: StreamState,
+    handshake: Handshake,
+    closing: Closing,
+    pending_pong: Option<Vec<u8>>,
+    pending_close: Option<Frame>,
+    frame_decoder: FrameDecoder,
+    frame_encoder: FrameEncoder,
+}
+impl ProxyChannel {
+    pub fn new(logger: Logger, ws_stream: TcpStream, real_server_addr: SocketAddr) -> Self {
+        let _ = ws_stream.set_nodelay(true);
+        info!(logger, "New proxy channel is created");
+        ProxyChannel {
+            logger,
+            ws_stream,
+            ws_rbuf: ReadBuf::new(vec![0; BUF_SIZE]),
+            ws_wbuf: WriteBuf::new(vec![0; BUF_SIZE]),
+            real_server_addr,
+            real_stream: None,
+            real_stream_rstate: StreamState::Normal,
+            real_stream_wstate: StreamState::Normal,
+            handshake: Handshake::new(),
+            closing: Closing::NotYet,
+            pending_pong: None,
+            pending_close: None,
+            frame_decoder: FrameDecoder::default(),
+            frame_encoder: FrameEncoder::default(),
+        }
+    }
+
+    fn process_handshake(&mut self, cx: &mut Context) -> bool {
+        loop {
+            match mem::replace(&mut self.handshake, Handshake::Done) {
+                Handshake::RecvRequest(mut decoder) => {
+                    let result = decoder.decode_from_read_buf(&mut self.ws_rbuf);
+                    if result.is_ok() && !decoder.is_idle() {
+                        self.handshake = Handshake::RecvRequest(decoder);
+                        break;
+                    }
+                    match result.and_then(|()| decoder.finish_decoding()) {
+                        Err(e) => {
+                            warn!(self.logger, "Malformed HTTP request: {}", e);
+                            self.handshake = Handshake::response_bad_request();
+                        }
+                        Ok(request) => {
+                            debug!(self.logger, "Received a WebSocket handshake request");
+                            debug!(self.logger, "Method: {}", request.method());
+                            debug!(self.logger, "Target: {}", request.request_target());
+                            debug!(self.logger, "Version: {}", request.http_version());
+                            debug!(self.logger, "Header: {}", request.header());
+
+                            match track!(self.handle_handshake_request(&request)) {
+                                Err(e) => {
+                                    warn!(
+                                        self.logger,
+                                        "Invalid WebSocket handshake request: {}", e
+                                    );
+                                    self.handshake = Handshake::response_bad_request();
+                                }
+                                Ok(key) => {
+                                    debug!(self.logger, "Tries to connect the real server");
+                                    let future = TcpStream::connect(self.real_server_addr);
+                                    self.handshake =
+                                        Handshake::ConnectToRealServer(Box::pin(future), key);
+                                }
+                            }
+                        }
+                    }
+                }
+                Handshake::ConnectToRealServer(mut f, key) => {
+                    match Pin::new(&mut f).poll(cx).map_err(Error::from) {
+                        Poll::Pending => {
+                            self.handshake = Handshake::ConnectToRealServer(f, key);
+                            break;
+                        }
+                        Poll::Ready(Err(e)) => {
+                            warn!(self.logger, "Cannot connect to the real server: {}", e);
+                            self.handshake = Handshake::response_unavailable();
+                        }
+                        Poll::Ready(Ok(stream)) => {
+                            debug!(self.logger, "Connected to the real server");
+                            let _ = stream.set_nodelay(true);
+                            if let Ok(addr) = stream.local_addr() {
+                                self.logger = self.logger.new(o!("relay_addr" => addr.to_string()));
+                            }
+                            self.handshake = Handshake::response_accepted(&key);
+                            self.real_stream = Some(stream);
+                        }
+                    }
+                }
+                Handshake::SendResponse(mut encoder, succeeded) => {
+                    if let Err(e) = track!(encoder.encode_to_write_buf(&mut self.ws_wbuf)) {
+                        warn!(self.logger, "Cannot write a handshake response: {}", e);
+                        return false;
+                    }
+                    if encoder.is_idle() {
+                        debug!(self.logger, "Handshake response has been written");
+                        if succeeded {
+                            info!(self.logger, "WebSocket handshake succeeded");
+                            self.handshake = Handshake::Done;
+                        } else {
+                            return false;
+                        }
+                    } else {
+                        self.handshake = Handshake::SendResponse(encoder, succeeded);
+                    }
+                    break;
+                }
+                Handshake::Done => {
+                    break;
+                }
+            }
+        }
+        true
+    }
+
+    fn handle_handshake_request(&mut self, request: &Request<()>) -> Result<WebSocketKey> {
+        track_assert_eq!(request.method().as_str(), "GET", ErrorKind::InvalidInput);
+        track_assert_eq!(
+            request.http_version(),
+            HttpVersion::V1_1,
+            ErrorKind::InvalidInput
+        );
+
+        let mut key = None;
+        for field in request.header().fields() {
+            let name = field.name();
+            let value = field.value();
+            if name.eq_ignore_ascii_case("upgrade") {
+                track_assert_eq!(value, "websocket", ErrorKind::InvalidInput);
+            } else if name.eq_ignore_ascii_case("connection") {
+                let mut values = value.split(',');
+                track_assert!(values.any(|v| v.trim() == "Upgrade"), ErrorKind::InvalidInput; value);
+            } else if name.eq_ignore_ascii_case("sec-websocket-key") {
+                key = Some(value.to_owned());
+            } else if name.eq_ignore_ascii_case("sec-websocket-version") {
+                track_assert_eq!(value, "13", ErrorKind::InvalidInput);
+            }
+        }
+
+        let key = track_assert_some!(key, ErrorKind::InvalidInput);
+        Ok(WebSocketKey(key))
+    }
+
+    fn process_relay(&mut self, cx: &mut Context) -> Result<()> {
+        if let Err(e) = track!(self.handle_real_stream(cx)) {
+            warn!(self.logger, "{}", e);
+            track!(self.starts_closing(1001, false))?;
+        }
+        if let Err(e) = track!(self.handle_ws_stream()) {
+            warn!(self.logger, "{}", e);
+            track!(self.starts_closing(1002, false))?;
+        }
+        Ok(())
+    }
+
+    fn handle_real_stream(&mut self, cx: &mut Context) -> Result<()> {
+        if let Some(stream) = self.real_stream.as_mut() {
+            self.real_stream_rstate = track!(self
+                .frame_encoder
+                .start_encoding_data(SyncReader::new(stream, cx)))?;
+            self.real_stream_wstate = track!(self
+                .frame_decoder
+                .write_decoded_data(SyncWriter::new(stream, cx)))?;
+        }
+        Ok(())
+    }
+
+    fn handle_ws_stream(&mut self) -> Result<()> {
+        if self.frame_encoder.is_idle() {
+            if let Some(data) = self.pending_pong.take() {
+                debug!(self.logger, "Sends Ping frame: {:?}", data);
+                track!(self.frame_encoder.start_encoding(Frame::Pong { data }))?;
+            }
+        }
+        if self.frame_encoder.is_idle() {
+            if let Some(frame) = self.pending_close.take() {
+                track!(self.frame_encoder.start_encoding(frame))?;
+            }
+        }
+
+        track!(self.frame_encoder.encode_to_write_buf(&mut self.ws_wbuf))?;
+        if self.frame_encoder.is_idle() && self.closing.is_client_closed() {
+            self.closing = Closing::Closed;
+        }
+
+        track!(self.frame_decoder.decode_from_read_buf(&mut self.ws_rbuf))?;
+        if self.frame_decoder.is_idle() {
+            let frame = track!(self.frame_decoder.finish_decoding())?;
+            debug!(self.logger, "Received frame: {:?}", frame);
+            track!(self.handle_frame(frame))?;
+        }
+        Ok(())
+    }
+
+    fn handle_frame(&mut self, frame: Frame) -> Result<()> {
+        match frame {
+            Frame::ConnectionClose { code, reason } => {
+                info!(
+                    self.logger,
+                    "Received Close frame: code={}, reason={:?}",
+                    code,
+                    String::from_utf8(reason)
+                );
+                match self.closing {
+                    Closing::NotYet => {
+                        track!(self.starts_closing(code, true))?;
+                    }
+                    Closing::InProgress {
+                        ref mut client_closed,
+                    } => {
+                        *client_closed = true;
+                    }
+                    _ => track_panic!(ErrorKind::Other; self.closing),
+                }
+            }
+            Frame::Ping { data } => {
+                if self.closing.is_not_yet() {
+                    self.pending_pong = Some(data);
+                }
+            }
+            Frame::Pong { .. } | Frame::Data => {}
+        }
+        Ok(())
+    }
+
+    fn starts_closing(&mut self, code: u16, client_closed: bool) -> Result<()> {
+        track_assert_eq!(self.closing, Closing::NotYet, ErrorKind::Other);
+        self.real_stream = None;
+        self.real_stream_rstate = StreamState::Eos;
+        self.real_stream_wstate = StreamState::Eos;
+        self.closing = Closing::InProgress { client_closed };
+        self.pending_close = Some(Frame::ConnectionClose {
+            code,
+            reason: Vec::new(),
+        });
+        Ok(())
+    }
+
+    fn is_ws_stream_eos(&self) -> bool {
+        self.ws_rbuf.stream_state().is_eos() || self.ws_wbuf.stream_state().is_eos()
+    }
+
+    fn is_real_stream_eos(&self) -> bool {
+        self.real_stream_rstate.is_eos() || self.real_stream_wstate.is_eos()
+    }
+
+    fn would_ws_stream_block(&self) -> bool {
+        let empty_write =
+            self.ws_wbuf.is_empty() && self.pending_close.is_none() && self.pending_pong.is_none();
+        self.ws_rbuf.stream_state().would_block()
+            && (empty_write || self.ws_wbuf.stream_state().would_block())
+    }
+
+    fn would_real_stream_block(&self) -> bool {
+        self.real_stream_rstate.would_block()
+            && (self.frame_decoder.is_data_empty() || self.real_stream_wstate.would_block())
+    }
+}
+impl Future for ProxyChannel {
+    type Output = Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            // WebSocket TCP stream I/O
+            track!(this.ws_rbuf.fill(SyncReader::new(&mut this.ws_stream, cx)))?;
+            track!(this.ws_wbuf.flush(SyncWriter::new(&mut this.ws_stream, cx)))?;
+            if this.is_ws_stream_eos() {
+                info!(this.logger, "TCP stream for WebSocket has been closed");
+                return Poll::Ready(Ok(()));
+            }
+
+            // WebSocket handshake
+            if !this.process_handshake(cx) {
+                warn!(this.logger, "WebSocket handshake cannot be completed");
+                return Poll::Ready(Ok(()));
+            }
+            if !this.handshake.done() {
+                if this.would_ws_stream_block() {
+                    return Poll::Pending;
+                }
+                continue;
+            }
+
+            if this.closing == Closing::Closed {
+                info!(this.logger, "WebSocket channel has been closed normally");
+                return Poll::Ready(Ok(()));
+            }
+
+            // Relay
+            track!(this.process_relay(cx))?;
+            if this.is_real_stream_eos() && this.closing.is_not_yet() {
+                info!(this.logger, "TCP stream for a real server has been closed");
+                track!(this.starts_closing(1000, false))?;
+            }
+            if this.would_ws_stream_block() && this.would_real_stream_block() {
+                return Poll::Pending;
+            }
+        }
+    }
+}
+
+enum Handshake {
+    RecvRequest(RequestDecoder<NoBodyDecoder>),
+    ConnectToRealServer(
+        Pin<Box<(dyn Future<Output = async_std::io::Result<TcpStream>> + Send + 'static)>>,
+        WebSocketKey,
+    ),
+    SendResponse(ResponseEncoder<NoBodyEncoder>, bool),
+    Done,
+}
+impl Handshake {
+    fn new() -> Self {
+        Handshake::RecvRequest(RequestDecoder::default())
+    }
+
+    fn done(&self) -> bool {
+        if let Handshake::Done = *self {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn response_accepted(key: &WebSocketKey) -> Self {
+        let hash = util::calc_accept_hash(&key);
+
+        unsafe {
+            let mut response = Response::new(
+                HttpVersion::V1_1,
+                StatusCode::new_unchecked(101),
+                ReasonPhrase::new_unchecked("Switching Protocols"),
+                (),
+            );
+            response
+                .header_mut()
+                .add_field(HeaderField::new_unchecked("Upgrade", "websocket"))
+                .add_field(HeaderField::new_unchecked("Connection", "Upgrade"))
+                .add_field(HeaderField::new_unchecked("Sec-WebSocket-Accept", &hash));
+
+            let encoder = ResponseEncoder::with_item(response).expect("Never fails");
+            Handshake::SendResponse(encoder, true)
+        }
+    }
+
+    fn response_bad_request() -> Self {
+        unsafe {
+            let mut response = Response::new(
+                HttpVersion::V1_1,
+                StatusCode::new_unchecked(400),
+                ReasonPhrase::new_unchecked("Bad Request"),
+                (),
+            );
+            response
+                .header_mut()
+                .add_field(HeaderField::new_unchecked("Content-Length", "0"));
+            let encoder = ResponseEncoder::with_item(response).expect("Never fails");
+            Handshake::SendResponse(encoder, false)
+        }
+    }
+
+    fn response_unavailable() -> Self {
+        unsafe {
+            let mut response = Response::new(
+                HttpVersion::V1_1,
+                StatusCode::new_unchecked(503),
+                ReasonPhrase::new_unchecked("Service Unavailable"),
+                (),
+            );
+            response
+                .header_mut()
+                .add_field(HeaderField::new_unchecked("Content-Length", "0"));
+            let encoder = ResponseEncoder::with_item(response).expect("Never fails");
+            Handshake::SendResponse(encoder, false)
+        }
+    }
+}
+
+impl std::fmt::Debug for Handshake {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Handshake {{ .. }}")
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Closing {
+    NotYet,
+    InProgress { client_closed: bool },
+    Closed,
+}
+impl Closing {
+    fn is_not_yet(&self) -> bool {
+        *self == Closing::NotYet
+    }
+
+    fn is_client_closed(&self) -> bool {
+        *self
+            == Closing::InProgress {
+                client_closed: true,
+            }
+    }
+}
+
+#[derive(Debug)]
+struct SyncReader<'a, 'b, 'c, T> {
+    inner: &'a mut T,
+    cx: &'b mut Context<'c>,
+}
+
+impl<'a, 'b, 'c, T: async_std::io::Read> SyncReader<'a, 'b, 'c, T> {
+    fn new(inner: &'a mut T, cx: &'b mut Context<'c>) -> Self {
+        Self { inner, cx }
+    }
+}
+
+impl<'a, 'b, 'c, T> std::io::Read for SyncReader<'a, 'b, 'c, T>
+where
+    T: async_std::io::Read + std::marker::Unpin,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match Pin::new(&mut *self.inner).poll_read(self.cx, buf) {
+            Poll::Pending => Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Would block",
+            )),
+            Poll::Ready(result) => result,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SyncWriter<'a, 'b, 'c, T> {
+    inner: &'a mut T,
+    cx: &'b mut Context<'c>,
+}
+
+impl<'a, 'b, 'c, T: async_std::io::Write> SyncWriter<'a, 'b, 'c, T> {
+    fn new(inner: &'a mut T, cx: &'b mut Context<'c>) -> Self {
+        Self { inner, cx }
+    }
+}
+
+impl<'a, 'b, 'c, T> std::io::Write for SyncWriter<'a, 'b, 'c, T>
+where
+    T: async_std::io::Write + std::marker::Unpin,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match Pin::new(&mut *self.inner).poll_write(self.cx, buf) {
+            Poll::Pending => Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Would block",
+            )),
+            Poll::Ready(result) => result,
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match Pin::new(&mut *self.inner).poll_flush(self.cx) {
+            Poll::Pending => Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "Would block",
+            )),
+            Poll::Ready(result) => result,
+        }
+    }
+}

--- a/src/wstcp/frame.rs
+++ b/src/wstcp/frame.rs
@@ -1,0 +1,446 @@
+use crate::opcode::Opcode;
+use crate::{Error, Result};
+use bytecodec::bytes::{BytesEncoder, CopyableBytesDecoder};
+use bytecodec::combinator::Slice;
+use bytecodec::io::StreamState;
+use bytecodec::{self, ByteCount, Decode, Encode, Eos};
+use byteorder::{BigEndian, ByteOrder};
+use std::cmp;
+use std::io::{self, Read, Write};
+
+const FIN_FLAG: u8 = 0b1000_0000;
+const MASK_FLAG: u8 = 0b1000_0000;
+
+const BUF_SIZE: usize = 4096;
+
+#[derive(Debug)]
+pub enum Frame {
+    ConnectionClose { code: u16, reason: Vec<u8> },
+    Ping { data: Vec<u8> },
+    Pong { data: Vec<u8> },
+    Data,
+}
+
+#[derive(Debug, Clone)]
+struct FrameHeader {
+    fin_flag: bool,
+    opcode: Opcode,
+    mask: Option<[u8; 4]>,
+    payload_len: u64,
+}
+impl FrameHeader {
+    fn from_bytes(b: [u8; 2]) -> bytecodec::Result<Self> {
+        let mut header = FrameHeader {
+            fin_flag: (b[0] & FIN_FLAG) != 0,
+            opcode: track!(Opcode::from_u8(b[0] & 0b1111))?,
+            mask: None,
+            payload_len: u64::from(b[1] & 0b0111_1111),
+        };
+
+        let mask_flag = (b[1] & MASK_FLAG) != 0;
+        if mask_flag {
+            header.mask = Some([0; 4]); // dummy
+        }
+        Ok(header)
+    }
+}
+
+#[derive(Debug)]
+pub struct FrameEncoder {
+    header: Slice<BytesEncoder<[u8; 2 + 8]>>,
+    payload: Vec<u8>,
+    payload_offset: usize,
+    payload_length: usize,
+}
+impl FrameEncoder {
+    pub fn start_encoding_data<R: Read>(&mut self, mut reader: R) -> Result<StreamState> {
+        if !self.is_idle() {
+            return Ok(StreamState::Normal);
+        }
+
+        match reader.read(&mut self.payload) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    return Ok(StreamState::WouldBlock);
+                } else {
+                    return Err(track!(Error::from(e)));
+                }
+            }
+            Ok(0) => return Ok(StreamState::Eos),
+            Ok(size) => {
+                track!(self.start_encoding_header(Opcode::BinaryFrame, size))?;
+            }
+        }
+        Ok(StreamState::Normal)
+    }
+
+    fn start_encoding_header(
+        &mut self,
+        opcode: Opcode,
+        payload_len: usize,
+    ) -> bytecodec::Result<()> {
+        let header_size;
+        let mut header = [0; 2 + 8];
+        header[0] = FIN_FLAG | (opcode as u8);
+        if payload_len < 126 {
+            header[1] = payload_len as u8;
+            header_size = 2;
+        } else if payload_len < 0x10000 {
+            header[1] = 126;
+            BigEndian::write_u16(&mut header[2..], payload_len as u16);
+            header_size = 4;
+        } else {
+            header[1] = 127;
+            BigEndian::write_u64(&mut header[2..], payload_len as u64);
+            header_size = 10;
+        };
+
+        track!(self.header.start_encoding(header))?;
+        self.header.set_consumable_bytes(header_size);
+        self.payload_length = payload_len;
+        Ok(())
+    }
+}
+impl Encode for FrameEncoder {
+    type Item = Frame;
+
+    fn encode(&mut self, buf: &mut [u8], eos: Eos) -> bytecodec::Result<usize> {
+        let mut offset = 0;
+        if !self.header.is_suspended() {
+            offset += track!(self.header.encode(buf, eos))?;
+            if !self.header.is_suspended() {
+                return Ok(offset);
+            }
+        }
+
+        let size = cmp::min(
+            buf.len() - offset,
+            self.payload_length - self.payload_offset,
+        );
+        (&mut buf[offset..][..size]).copy_from_slice(&self.payload[self.payload_offset..][..size]);
+        self.payload_offset += size;
+        if self.payload_offset == self.payload_length {
+            self.payload_length = 0;
+            self.payload_offset = 0;
+            self.header = Default::default();
+        }
+        Ok(offset + size)
+    }
+
+    fn start_encoding(&mut self, item: Self::Item) -> bytecodec::Result<()> {
+        track_assert!(self.is_idle(), bytecodec::ErrorKind::EncoderFull);
+        match item {
+            Frame::ConnectionClose { code, reason } => {
+                track!(self.start_encoding_header(Opcode::ConnectionClose, 2 + reason.len()))?;
+                self.payload_length = 2 + reason.len();
+                track_assert!(
+                    self.payload_length <= self.payload.len(),
+                    bytecodec::ErrorKind::InvalidInput
+                );
+                BigEndian::write_u16(&mut self.payload, code);
+                (&mut self.payload[2..][..reason.len()]).copy_from_slice(&reason);
+            }
+            Frame::Pong { data } => {
+                track!(self.start_encoding_header(Opcode::Pong, data.len()))?;
+                self.payload_length = data.len();
+                track_assert!(
+                    self.payload_length <= self.payload.len(),
+                    bytecodec::ErrorKind::InvalidInput
+                );
+                (&mut self.payload[..data.len()]).copy_from_slice(&data);
+            }
+            Frame::Ping { .. } | Frame::Data => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn is_idle(&self) -> bool {
+        self.header.is_idle() && self.payload_length == 0
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        let n = self.header.consumable_bytes() + (self.payload_length - self.payload_offset) as u64;
+        ByteCount::Finite(n)
+    }
+}
+impl Default for FrameEncoder {
+    fn default() -> Self {
+        FrameEncoder {
+            header: Default::default(),
+            payload: vec![0; 4096],
+            payload_length: 0,
+            payload_offset: 0,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct FrameHeaderDecoder {
+    fixed_bytes: CopyableBytesDecoder<[u8; 2]>,
+    extended_bytes: CopyableBytesDecoder<ExtendedHeaderBytes>,
+    header: Option<FrameHeader>,
+    completed: bool,
+}
+impl Decode for FrameHeaderDecoder {
+    type Item = FrameHeader;
+
+    fn decode(&mut self, buf: &[u8], eos: Eos) -> bytecodec::Result<usize> {
+        if self.completed {
+            return Ok(0);
+        }
+
+        let mut offset = 0;
+        if self.header.is_none() {
+            bytecodec_try_decode!(self.fixed_bytes, offset, buf, eos);
+            let b = track!(self.fixed_bytes.finish_decoding())?;
+            let header = track!(FrameHeader::from_bytes(b))?;
+
+            self.extended_bytes.inner_mut().size = 0;
+            if header.mask.is_some() {
+                self.extended_bytes.inner_mut().size = 4;
+            }
+            match header.payload_len {
+                126 => {
+                    self.extended_bytes.inner_mut().size += 2;
+                }
+                127 => {
+                    self.extended_bytes.inner_mut().size += 8;
+                }
+                _ => {}
+            }
+            self.header = Some(header);
+        }
+
+        bytecodec_try_decode!(self.extended_bytes, offset, buf, eos);
+        let b = track!(self.extended_bytes.finish_decoding())?;
+        let header = self.header.as_mut().expect("Never fails");
+        let mut bytes = &b.bytes[..];
+        match header.payload_len {
+            126 => {
+                header.payload_len = u64::from(BigEndian::read_u16(bytes));
+                bytes = &bytes[2..];
+            }
+            127 => {
+                header.payload_len = BigEndian::read_u64(bytes);
+                bytes = &bytes[8..];
+            }
+            _ => {}
+        }
+        if header.mask.is_some() {
+            header.mask = Some([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        }
+        self.completed = true;
+        Ok(offset)
+    }
+
+    fn finish_decoding(&mut self) -> bytecodec::Result<Self::Item> {
+        track_assert!(self.completed, bytecodec::ErrorKind::IncompleteDecoding);
+        let header =
+            track_assert_some!(self.header.take(), bytecodec::ErrorKind::InconsistentState);
+        self.completed = false;
+        Ok(header)
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        if self.completed {
+            ByteCount::Finite(0)
+        } else {
+            self.fixed_bytes
+                .requiring_bytes()
+                .add_for_decoding(self.extended_bytes.requiring_bytes())
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FramePayloadDecoder {
+    buf: Vec<u8>,
+    buf_start: usize,
+    buf_end: usize,
+    payload_offset: u64,
+    mask_offset: usize,
+    header: Option<FrameHeader>,
+}
+impl Decode for FramePayloadDecoder {
+    type Item = Frame;
+
+    fn decode(&mut self, buf: &[u8], eos: Eos) -> bytecodec::Result<usize> {
+        if let Some(ref header) = self.header {
+            let size =
+                cmp::min(header.payload_len - self.payload_offset, buf.len() as u64) as usize;
+            let size = cmp::min(size, self.buf.len() - self.buf_end);
+            (&mut self.buf[self.buf_end..][..size]).copy_from_slice(&buf[..size]);
+            self.buf_end += size;
+            self.payload_offset += size as u64;
+            if let Some(mask) = header.mask {
+                let start = self.buf_end - size;
+                for b in &mut self.buf[start..self.buf_end] {
+                    *b ^= mask[self.mask_offset];
+                    self.mask_offset = (self.mask_offset + 1) % 4;
+                }
+            }
+            if self.payload_offset != header.payload_len {
+                track_assert!(!eos.is_reached(), bytecodec::ErrorKind::UnexpectedEos);
+            }
+            Ok(size)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn finish_decoding(&mut self) -> bytecodec::Result<Self::Item> {
+        track_assert!(self.is_idle(), bytecodec::ErrorKind::IncompleteDecoding);
+        let header =
+            track_assert_some!(self.header.take(), bytecodec::ErrorKind::InconsistentState);
+        let frame = match header.opcode {
+            Opcode::ConnectionClose => {
+                track_assert_eq!(self.buf_start, 0, bytecodec::ErrorKind::InconsistentState);
+                track_assert!(self.buf_end >= 2, bytecodec::ErrorKind::InvalidInput);
+                let code = BigEndian::read_u16(&self.buf);
+                let reason = Vec::from(&self.buf[2..self.buf_end]);
+                Frame::ConnectionClose { code, reason }
+            }
+            Opcode::Ping => {
+                track_assert_eq!(self.buf_start, 0, bytecodec::ErrorKind::InconsistentState);
+                let data = Vec::from(&self.buf[..self.buf_end]);
+                Frame::Ping { data }
+            }
+            Opcode::Pong => {
+                track_assert_eq!(self.buf_start, 0, bytecodec::ErrorKind::InconsistentState);
+                let data = Vec::from(&self.buf[..self.buf_end]);
+                Frame::Pong { data }
+            }
+            _ => {
+                track_assert_eq!(
+                    self.buf_start,
+                    self.buf_end,
+                    bytecodec::ErrorKind::InconsistentState
+                );
+                Frame::Data
+            }
+        };
+        self.buf_start = 0;
+        self.buf_end = 0;
+        self.payload_offset = 0;
+        self.mask_offset = 0;
+        Ok(frame)
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        if let Some(ref header) = self.header {
+            ByteCount::Finite(header.payload_len - self.payload_offset)
+        } else {
+            ByteCount::Unknown
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        if let Some(ref header) = self.header {
+            if header.payload_len == self.payload_offset {
+                match header.opcode {
+                    Opcode::ConnectionClose | Opcode::Ping | Opcode::Pong => true,
+                    _ => self.buf_start == self.buf_end,
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+}
+impl Default for FramePayloadDecoder {
+    fn default() -> Self {
+        FramePayloadDecoder {
+            buf: vec![0; BUF_SIZE],
+            buf_start: 0,
+            buf_end: 0,
+            payload_offset: 0,
+            mask_offset: 0,
+            header: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FrameDecoder {
+    header: FrameHeaderDecoder,
+    payload: FramePayloadDecoder,
+}
+impl FrameDecoder {
+    pub fn write_decoded_data<W: Write>(&mut self, mut writer: W) -> Result<StreamState> {
+        if self.is_data_empty() {
+            return Ok(StreamState::Normal);
+        }
+
+        let buf = &self.payload.buf[self.payload.buf_start..self.payload.buf_end];
+        match writer.write(buf) {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    Ok(StreamState::WouldBlock)
+                } else {
+                    Err(track!(Error::from(e)))
+                }
+            }
+            Ok(0) => Ok(StreamState::Eos),
+            Ok(size) => {
+                self.payload.buf_start += size;
+                if self.payload.buf_start == self.payload.buf_end {
+                    self.payload.buf_start = 0;
+                    self.payload.buf_end = 0;
+                }
+                Ok(StreamState::Normal)
+            }
+        }
+    }
+
+    pub fn is_data_empty(&self) -> bool {
+        self.payload.header.as_ref().map_or(true, |h| {
+            h.opcode.is_control() || self.payload.buf_start == self.payload.buf_end
+        })
+    }
+}
+impl Decode for FrameDecoder {
+    type Item = Frame;
+
+    fn decode(&mut self, buf: &[u8], eos: Eos) -> bytecodec::Result<usize> {
+        let mut offset = 0;
+        if self.payload.header.is_none() {
+            bytecodec_try_decode!(self.header, offset, buf, eos);
+            let header = track!(self.header.finish_decoding())?;
+            self.payload.header = Some(header);
+        }
+        bytecodec_try_decode!(self.payload, offset, buf, eos);
+        Ok(offset)
+    }
+
+    fn finish_decoding(&mut self) -> bytecodec::Result<Self::Item> {
+        track!(self.payload.finish_decoding())
+    }
+
+    fn requiring_bytes(&self) -> ByteCount {
+        self.header
+            .requiring_bytes()
+            .add_for_decoding(self.payload.requiring_bytes())
+    }
+
+    fn is_idle(&self) -> bool {
+        self.payload.is_idle()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ExtendedHeaderBytes {
+    bytes: [u8; 12],
+    size: usize,
+}
+impl AsRef<[u8]> for ExtendedHeaderBytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes[..self.size]
+    }
+}
+impl AsMut<[u8]> for ExtendedHeaderBytes {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[..self.size]
+    }
+}

--- a/src/wstcp/mod.rs
+++ b/src/wstcp/mod.rs
@@ -1,0 +1,29 @@
+use crate::wstcp::server::ProxyServer;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+
+pub mod channel;
+pub mod frame;
+pub mod opcode;
+pub mod server;
+pub mod util;
+
+pub fn start_ws_proxy(bind_addr: SocketAddr, rpc_addr: SocketAddr) {
+    let forward_addr = if rpc_addr.ip().is_unspecified() {
+        // RPC bind address is 0.0.0.0, so we can't forward to that.
+        // Use localhost.
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_addr.port())
+    } else {
+        rpc_addr
+    };
+
+    async_std::task::block_on(async {
+        let proxy = ProxyServer::new(bind_addr, forward_addr)
+            .await
+            .unwrap_or_else(|e| panic!("{}", e));
+        info!("WebSocket initalized");
+        proxy.run_accept_loop().await.expect("WebSocket error");
+    });
+    info!("WebSocket closed")
+}

--- a/src/wstcp/opcode.rs
+++ b/src/wstcp/opcode.rs
@@ -1,0 +1,31 @@
+use bytecodec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Opcode {
+    ContinuationFrame = 0x0,
+    TextFrame = 0x1,
+    BinaryFrame = 0x2,
+    ConnectionClose = 0x8,
+    Ping = 0x9,
+    Pong = 0xA,
+}
+impl Opcode {
+    pub fn from_u8(n: u8) -> bytecodec::Result<Self> {
+        Ok(match n {
+            0x0 => Opcode::ContinuationFrame,
+            0x1 => Opcode::TextFrame,
+            0x2 => Opcode::BinaryFrame,
+            0x8 => Opcode::ConnectionClose,
+            0x9 => Opcode::Ping,
+            0xA => Opcode::Pong,
+            _ => track_panic!(bytecodec::ErrorKind::InvalidInput, "Unknown opcode: {}", n),
+        })
+    }
+
+    pub fn is_control(&self) -> bool {
+        match *self {
+            Opcode::ConnectionClose | Opcode::Ping | Opcode::Pong => true,
+            _ => false,
+        }
+    }
+}

--- a/src/wstcp/opcode.rs
+++ b/src/wstcp/opcode.rs
@@ -1,5 +1,3 @@
-use bytecodec;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Opcode {
     ContinuationFrame = 0x0,
@@ -18,14 +16,11 @@ impl Opcode {
             0x8 => Opcode::ConnectionClose,
             0x9 => Opcode::Ping,
             0xA => Opcode::Pong,
-            _ => track_panic!(bytecodec::ErrorKind::InvalidInput, "Unknown opcode: {}", n),
+            _ => return Err(bytecodec::ErrorKind::InvalidInput.into()),
         })
     }
 
     pub fn is_control(&self) -> bool {
-        match *self {
-            Opcode::ConnectionClose | Opcode::Ping | Opcode::Pong => true,
-            _ => false,
-        }
+        matches!(*self, Opcode::ConnectionClose | Opcode::Ping | Opcode::Pong)
     }
 }

--- a/src/wstcp/server.rs
+++ b/src/wstcp/server.rs
@@ -1,0 +1,81 @@
+use crate::channel::ProxyChannel;
+use crate::{Error, Result};
+use async_std::net::TcpListener;
+use async_std::stream::Stream;
+use slog::Logger;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+/// WebSocket to TCP proxy server.
+#[derive(Debug)]
+pub struct ProxyServer {
+    logger: Logger,
+    proxy_addr: SocketAddr,
+    real_server_addr: SocketAddr,
+    listener: TcpListener,
+}
+impl ProxyServer {
+    /// Makes a new `ProxyServer` instance.
+    pub async fn new(
+        logger: Logger,
+        proxy_addr: SocketAddr,
+        real_server_addr: SocketAddr,
+    ) -> Result<Self> {
+        let logger = logger.new(
+            o!("proxy_addr" => proxy_addr.to_string(), "server_addr" => real_server_addr.to_string()),
+        );
+        info!(logger, "Starts a WebSocket proxy server");
+        let listener = track!(TcpListener::bind(proxy_addr).await.map_err(Error::from))?;
+        Ok(ProxyServer {
+            logger,
+            proxy_addr,
+            real_server_addr,
+            listener,
+        })
+    }
+}
+impl Future for ProxyServer {
+    type Output = Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            match Pin::new(&mut this.listener.incoming()).poll_next(cx) {
+                Poll::Pending => {
+                    break;
+                }
+                Poll::Ready(None) => {
+                    warn!(
+                        this.logger,
+                        "TCP socket for the WebSocket proxy server has been closed"
+                    );
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(Err(track!(Error::from(e))));
+                }
+                Poll::Ready(Some(Ok(stream))) => {
+                    let addr = stream.peer_addr()?;
+                    debug!(this.logger, "New client arrived: {}", addr);
+
+                    let logger = this.logger.new(o!("client_addr" => addr.to_string()));
+                    let channel = ProxyChannel::new(logger.clone(), stream, this.real_server_addr);
+                    async_std::task::spawn(async move {
+                        match channel.await {
+                            Err(e) => {
+                                warn!(logger, "A proxy channel aborted: {}", e);
+                            }
+                            Ok(()) => {
+                                info!(logger, "A proxy channel terminated normally");
+                            }
+                        }
+                    });
+                }
+            }
+        }
+        Poll::Pending
+    }
+}

--- a/src/wstcp/server.rs
+++ b/src/wstcp/server.rs
@@ -1,81 +1,54 @@
-use crate::channel::ProxyChannel;
-use crate::{Error, Result};
+use crate::errors::*;
+use crate::wstcp::channel::ProxyChannel;
 use async_std::net::TcpListener;
-use async_std::stream::Stream;
-use slog::Logger;
-use std::future::Future;
 use std::net::SocketAddr;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
 
 /// WebSocket to TCP proxy server.
 #[derive(Debug)]
 pub struct ProxyServer {
-    logger: Logger,
     proxy_addr: SocketAddr,
     real_server_addr: SocketAddr,
     listener: TcpListener,
 }
 impl ProxyServer {
     /// Makes a new `ProxyServer` instance.
-    pub async fn new(
-        logger: Logger,
-        proxy_addr: SocketAddr,
-        real_server_addr: SocketAddr,
-    ) -> Result<Self> {
-        let logger = logger.new(
-            o!("proxy_addr" => proxy_addr.to_string(), "server_addr" => real_server_addr.to_string()),
-        );
-        info!(logger, "Starts a WebSocket proxy server");
-        let listener = track!(TcpListener::bind(proxy_addr).await.map_err(Error::from))?;
+    pub async fn new(proxy_addr: SocketAddr, real_server_addr: SocketAddr) -> Result<Self> {
+        info!("Starting a WebSocket server on {}", proxy_addr.to_string());
+        trace!("WebSocket proxy to {}", real_server_addr.to_string());
+        let listener = TcpListener::bind(proxy_addr)
+            .await
+            .expect("failed to bind websocket server");
         Ok(ProxyServer {
-            logger,
             proxy_addr,
             real_server_addr,
             listener,
         })
     }
-}
-impl Future for ProxyServer {
-    type Output = Result<()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
-        let this = self.get_mut();
+    pub async fn run_accept_loop(&self) -> Result<()> {
         loop {
-            match Pin::new(&mut this.listener.incoming()).poll_next(cx) {
-                Poll::Pending => {
-                    break;
-                }
-                Poll::Ready(None) => {
-                    warn!(
-                        this.logger,
-                        "TCP socket for the WebSocket proxy server has been closed"
-                    );
-                    return Poll::Ready(Ok(()));
-                }
-                Poll::Ready(Some(Err(e))) => {
-                    return Poll::Ready(Err(track!(Error::from(e))));
-                }
-                Poll::Ready(Some(Ok(stream))) => {
-                    let addr = stream.peer_addr()?;
-                    debug!(this.logger, "New client arrived: {}", addr);
+            let stream = self.listener.accept().await;
 
-                    let logger = this.logger.new(o!("client_addr" => addr.to_string()));
-                    let channel = ProxyChannel::new(logger.clone(), stream, this.real_server_addr);
+            match stream {
+                Ok((stream, addr)) => {
+                    debug!("New connection: {}", addr);
+
+                    let channel = ProxyChannel::new(stream, self.real_server_addr);
                     async_std::task::spawn(async move {
                         match channel.await {
                             Err(e) => {
-                                warn!(logger, "A proxy channel aborted: {}", e);
+                                warn!("A proxy channel aborted: {}", e);
                             }
                             Ok(()) => {
-                                info!(logger, "A proxy channel terminated normally");
+                                info!("A proxy channel terminated normally");
                             }
                         }
                     });
                 }
+                Err(e) => {
+                    trace!("Incoming connection error {}", e);
+                }
             }
         }
-        Poll::Pending
     }
 }

--- a/src/wstcp/util.rs
+++ b/src/wstcp/util.rs
@@ -1,0 +1,25 @@
+use base64;
+use sha1::{Digest, Sha1};
+
+const GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+#[derive(Debug)]
+pub struct WebSocketKey(pub String);
+
+pub fn calc_accept_hash(key: &WebSocketKey) -> String {
+    let mut sh = Sha1::default();
+    sh.input(format!("{}{}", key.0, GUID).as_bytes());
+    let output = sh.result();
+    base64::encode(&output)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let hash = calc_accept_hash(&WebSocketKey("dGhlIHNhbXBsZSBub25jZQ==".to_owned()));
+        assert_eq!(hash, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+}


### PR DESCRIPTION
This adds experimental websocket support on ports 50003 for mainnet, 60003 for testnet.

It is currently implemented by proxying websocket connections to our RPC listening interface. It's implemented with code from the [wstcp](https://github.com/sile/wstcp/) project.

Ideally we should not be proxying, but rather responding to RPC requests directly on the websocket socket. This is the end goal, but requires more refactoring. This PR is first step towards good websocket support.

Test plan:

`./contrib/run_functional_tests.sh`

A websocket client has been added to `contrib/websocket-client`. 

```
websocket-client % node cli.js blockchain.address.get_balance bitcoincash:prnc2exht3zxlrqqcat690tc85cvfuypngh7szx6mk
{ confirmed: 217784148852, unconfirmed: 0 }
```

The PR is deployed on `bitcoincash.network`. When all instances of `bch.imaginary.cash` with `bitcoincash.network` in the [electrum-cash integration test](https://gitlab.com/GeneralProtocols/electrum-cash/library/-/blob/master/test/integration.test.ts), the tests pass.