### PR TITLE
rpc: Add RPC connection limit

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -163,3 +163,9 @@ name = "scripthash_alias_bytes_limit"
 type = "u32"
 doc = "The maximum number of bytes stored for scripthash aliases. A bitcoincash address alias is 54 bytes, making the default allow ~1800 blockchain.address subscriptions."
 default = "100000"
+
+[[param]]
+name = "rpc_max_connections"
+type = "u32"
+doc = "Maximum number of simultaneous RPC connections."
+default = "500"

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,7 @@ pub struct Config {
     pub rpc_buffer_size: usize,
     pub scripthash_subscription_limit: u32,
     pub scripthash_alias_bytes_limit: u32,
+    pub rpc_max_connections: u32,
 }
 
 /// Returns default daemon directory
@@ -304,6 +305,7 @@ impl Config {
             rpc_buffer_size: config.rpc_buffer_size,
             scripthash_subscription_limit: config.scripthash_subscription_limit,
             scripthash_alias_bytes_limit: config.scripthash_alias_bytes_limit,
+            rpc_max_connections: config.rpc_max_connections,
         };
         eprintln!("{:?}", config);
         config
@@ -351,6 +353,7 @@ debug_struct! { Config,
     rpc_buffer_size,
     scripthash_subscription_limit,
     scripthash_alias_bytes_limit,
+    rpc_max_connections,
 }
 
 struct StaticCookie {

--- a/src/doslimit.rs
+++ b/src/doslimit.rs
@@ -1,4 +1,85 @@
 use crate::errors::*;
+use crate::metrics::Metrics;
+
+use prometheus::IntGauge;
+
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
+
+pub struct GlobalLimits {
+    /// Maximum number of connections we accept in total.
+    pub max_connections_total: i32,
+
+    /// Current total connections
+    total_connections: AtomicI32,
+
+    metric_connections: IntGauge,
+}
+
+impl GlobalLimits {
+    pub fn new(max_connections_total: u32, metric: &Metrics) -> GlobalLimits {
+        GlobalLimits {
+            max_connections_total: max_connections_total as i32,
+            total_connections: AtomicI32::new(0),
+            metric_connections: metric.gauge_int(prometheus::Opts::new(
+                "electrscash_rpc_connections",
+                "# of RPC connections",
+            )),
+        }
+    }
+
+    /// Increase connection count. Fails if maximum number of connections has
+    /// been reached. Returns the new connection count.
+    pub fn inc_connection(&self) -> Result<u32> {
+        let c =
+            self.total_connections
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                    if current < self.max_connections_total {
+                        Some(current + 1)
+                    } else {
+                        None
+                    }
+                });
+
+        if c.is_err() {
+            bail!(format!(
+                "Maximum connection limit of {} reached.",
+                self.max_connections_total
+            ))
+        };
+        let c = c.unwrap();
+        // fetch_update fetches the *previous* value, that we succesfully bumped by one.
+        let c = c + 1;
+        self.metric_connections.set(c as i64);
+        Ok(c as u32)
+    }
+
+    /// Decreases connection count.
+    pub fn dec_connection(&self) -> Result<u32> {
+        let c =
+            self.total_connections
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                    if current <= 0 {
+                        None
+                    } else {
+                        Some(current - 1)
+                    }
+                });
+        if c.is_err() {
+            bail!("Cannot decrease connection counter. Already at zero.");
+        }
+        let c = c.unwrap();
+        // fetch_update fetches the *previous* value, that we succesfully decreased by one.
+        let c = c - 1;
+        self.metric_connections.set(c as i64);
+        Ok(c as u32)
+    }
+
+    /// Get maximum connections allowed
+    pub fn max_connections(&self) -> u32 {
+        self.max_connections_total as u32
+    }
+}
 
 /// DoS limits per connection
 #[derive(Clone, Copy)]
@@ -9,7 +90,7 @@ pub struct ConnectionLimits {
     /// Maximum number of scripthash subscriptions per connection
     pub max_subscriptions: u32,
 
-    /// TODO: Maximum number of bytes used to alias scripthash subscriptions.
+    /// Maximum number of bytes used to alias scripthash subscriptions.
     /// (scripthash aliased by bitcoin cash address)
     pub max_alias_bytes: u32,
 }


### PR DESCRIPTION
This adds a limit to maximum number of simultaneous RPC connections. Any new connections after limit is reached will be immediately dropped.

Test plan:

New test added to `electrum_doslimit.py` to test this feature.
`./contrib/run_functional_tests.py`