### PR TITLE
dos: Limit connections by IP prefix

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -169,3 +169,9 @@ name = "rpc_max_connections"
 type = "u32"
 doc = "Maximum number of simultaneous RPC connections."
 default = "500"
+
+[[param]]
+name = "rpc_max_connections_shared_prefix"
+type = "u32"
+doc = "Maximum number of simultaneous RPC connections from IP's sharing first two octets (255.255.0.0 for IPv4)."
+default = "100"

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -93,7 +93,11 @@ fn run_server(config: &Config) -> Result<()> {
         config.scripthash_subscription_limit,
         config.scripthash_alias_bytes_limit,
     );
-    let global_limits = Arc::new(GlobalLimits::new(config.rpc_max_connections, &*metrics));
+    let global_limits = Arc::new(GlobalLimits::new(
+        config.rpc_max_connections,
+        config.rpc_max_connections_shared_prefix,
+        &*metrics,
+    ));
 
     let mut server: Option<RPC> = None; // Electrum RPC server
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,7 @@ pub struct Config {
     pub scripthash_subscription_limit: u32,
     pub scripthash_alias_bytes_limit: u32,
     pub rpc_max_connections: u32,
+    pub rpc_max_connections_shared_prefix: u32,
 }
 
 /// Returns default daemon directory
@@ -306,6 +307,7 @@ impl Config {
             scripthash_subscription_limit: config.scripthash_subscription_limit,
             scripthash_alias_bytes_limit: config.scripthash_alias_bytes_limit,
             rpc_max_connections: config.rpc_max_connections,
+            rpc_max_connections_shared_prefix: config.rpc_max_connections_shared_prefix,
         };
         eprintln!("{:?}", config);
         config
@@ -354,6 +356,7 @@ debug_struct! { Config,
     scripthash_subscription_limit,
     scripthash_alias_bytes_limit,
     rpc_max_connections,
+    rpc_max_connections_shared_prefix,
 }
 
 struct StaticCookie {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::thread;
 use std::time::Duration;
 
@@ -22,6 +22,14 @@ impl Metrics {
         Metrics {
             reg: prometheus::Registry::new(),
             addr,
+        }
+    }
+
+    /// Constructor for use in unittests
+    pub fn dummy() -> Metrics {
+        Metrics {
+            reg: prometheus::Registry::new(),
+            addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234),
         }
     }
 


### PR DESCRIPTION
Mitigation against one actor using all connection slots.

The choice of using IP prefix was out of simplicity. This is probably not a great way to segregate connections.

Limitations: Because of the way websockets are implemented, this is effectively also a global limit for websocket connections.

## Test plan

Unit test added for this feature.

`cargo test`
`./contrib/run_functional_tests.py`