### PR TITLE
refactor: Split out responsibility of Query

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ impl App {
     pub fn new(
         store: store::DBStore,
         index: index::Index,
-        daemon: daemon::Daemon,
+        daemon: Arc<daemon::Daemon>,
         config: &Config,
     ) -> Result<Arc<App>> {
         Ok(Arc::new(App {

--- a/src/bin/electrscash.rs
+++ b/src/bin/electrscash.rs
@@ -33,7 +33,7 @@ fn run_server(config: &Config) -> Result<()> {
         &*metrics,
     ));
 
-    let daemon = Daemon::new(
+    let daemon = Arc::new(Daemon::new(
         &config.daemon_dir,
         &config.blocks_dir,
         config.daemon_rpc_addr,
@@ -42,7 +42,7 @@ fn run_server(config: &Config) -> Result<()> {
         signal.clone(),
         blocktxids_cache,
         &*metrics,
-    )?;
+    )?);
     // Perform initial indexing.
     let compatible = {
         let store = DBStore::open(&config.db_path, config.low_memory, &*metrics);
@@ -86,7 +86,7 @@ fn run_server(config: &Config) -> Result<()> {
 
     let app = App::new(store, index, daemon, &config)?;
     let tx_cache = TransactionCache::new(config.tx_cache_size as u64, &*metrics);
-    let query = Query::new(app.clone(), &*metrics, tx_cache);
+    let query = Query::new(app.clone(), &*metrics, tx_cache)?;
     let relayfee = query.get_relayfee()?;
     let connection_limits = ConnectionLimits::new(
         config.rpc_timeout,

--- a/src/query/confirmed.rs
+++ b/src/query/confirmed.rs
@@ -1,0 +1,72 @@
+use crate::errors::*;
+use crate::query::primitives::{FundingOutput, SpendingInput};
+use crate::query::queryutil::{
+    find_spending_input, txoutrow_to_fundingoutput, txoutrows_by_script_hash,
+};
+use crate::query::tx::TxQuery;
+use crate::scripthash::FullHash;
+use crate::store::ReadStore;
+use crate::timeout::TimeoutTrigger;
+use std::sync::Arc;
+
+pub struct ConfirmedQuery {
+    txquery: Arc<TxQuery>,
+    duration: Arc<prometheus::HistogramVec>,
+}
+
+impl ConfirmedQuery {
+    pub fn new(txquery: Arc<TxQuery>, duration: Arc<prometheus::HistogramVec>) -> ConfirmedQuery {
+        ConfirmedQuery { txquery, duration }
+    }
+
+    /// Query for confirmed outputs that funding scripthash.
+    pub fn get_funding(
+        &self,
+        read_store: &dyn ReadStore,
+        scripthash: &FullHash,
+        txquery: &TxQuery,
+        timeout: &TimeoutTrigger,
+    ) -> Result<Vec<FundingOutput>> {
+        let timer = self
+            .duration
+            .with_label_values(&["confirmed_status_funding"])
+            .start_timer();
+        let funding = txoutrows_by_script_hash(read_store, scripthash);
+        timeout.check()?;
+        let funding = funding
+            .iter()
+            .map(|outrow| txoutrow_to_fundingoutput(read_store, outrow, None, txquery, timeout))
+            .collect();
+        timer.observe_duration();
+        funding
+    }
+
+    /// Query for confirmed inputs that have been spent from scripthash.
+    ///
+    /// This requires list of transactions funding the scripthash, obtained
+    /// with get_funding.
+    pub fn get_spending(
+        &self,
+        read_store: &dyn ReadStore,
+        confirmed_funding: &[FundingOutput],
+        timeout: &TimeoutTrigger,
+    ) -> Result<Vec<SpendingInput>> {
+        let timer = self
+            .duration
+            .with_label_values(&["confirmed_status_spending"])
+            .start_timer();
+
+        let mut spending = vec![];
+
+        for funding_output in confirmed_funding {
+            timeout.check()?;
+            if let Some(spent) =
+                find_spending_input(read_store, &funding_output, None, &*self.txquery, timeout)?
+            {
+                spending.push(spent);
+            }
+        }
+        timer.observe_duration();
+        Ok(spending)
+    }
+}

--- a/src/query/header.rs
+++ b/src/query/header.rs
@@ -1,0 +1,51 @@
+use crate::app::App;
+use crate::errors::*;
+use crate::mempool::MEMPOOL_HEIGHT;
+use crate::query::queryutil::txrow_by_txid;
+use crate::util::HeaderEntry;
+use bitcoincash::hash_types::Txid;
+use std::sync::Arc;
+
+pub struct HeaderQuery {
+    app: Arc<App>,
+}
+
+impl HeaderQuery {
+    pub fn new(app: Arc<App>) -> HeaderQuery {
+        HeaderQuery { app }
+    }
+
+    /// Get header for the block that given transaction was confirmed in.
+    /// Height is optional, but makes Lookup faster.
+    pub fn get_by_txid(
+        &self,
+        txid: &Txid,
+        blockheight: Option<u32>,
+    ) -> Result<Option<HeaderEntry>> {
+        // Lookup in confirmed transactions' index
+        let height = match blockheight {
+            Some(height) => {
+                if height == MEMPOOL_HEIGHT {
+                    return Ok(None);
+                }
+                height
+            }
+            None => {
+                txrow_by_txid(self.app.read_store(), &txid)
+                    .chain_err(|| format!("not indexed tx {}", txid))?
+                    .height
+            }
+        };
+
+        let header = self
+            .app
+            .index()
+            .get_header(height as usize)
+            .chain_err(|| format!("missing header at height {}", height))?;
+        Ok(Some(header))
+    }
+
+    pub fn best(&self) -> Option<HeaderEntry> {
+        self.app.index().best_header()
+    }
+}

--- a/src/query/primitives.rs
+++ b/src/query/primitives.rs
@@ -1,0 +1,20 @@
+use crate::mempool::ConfirmationState;
+use bitcoincash::hash_types::Txid;
+
+pub struct FundingOutput {
+    pub txn_id: Txid,
+    pub height: u32,
+    pub output_index: usize,
+    pub value: u64,
+    pub state: ConfirmationState,
+}
+
+pub type OutPoint = (Txid, usize); // (txid, output_index)
+
+pub struct SpendingInput {
+    pub txn_id: Txid,
+    pub height: u32,
+    pub funding_output: OutPoint,
+    pub value: u64,
+    pub state: ConfirmationState,
+}

--- a/src/query/queryutil.rs
+++ b/src/query/queryutil.rs
@@ -1,0 +1,189 @@
+use crate::errors::*;
+use crate::index::{TxInRow, TxOutRow, TxRow};
+use crate::mempool::{ConfirmationState, Tracker, MEMPOOL_HEIGHT};
+use crate::query::primitives::{FundingOutput, SpendingInput};
+use crate::query::tx::TxQuery;
+use crate::scripthash::compute_script_hash;
+use crate::store::{ReadStore, Row};
+use crate::timeout::TimeoutTrigger;
+use crate::util::{hash_prefix, HashPrefix};
+use bitcoincash::blockdata::transaction::Transaction;
+use bitcoincash::consensus::encode::deserialize;
+use bitcoincash::hash_types::Txid;
+
+pub struct TxnHeight {
+    pub txn: Transaction,
+    pub height: u32,
+}
+
+// TODO: the functions below can be part of ReadStore.
+pub fn txrow_by_txid(store: &dyn ReadStore, txid: &Txid) -> Option<TxRow> {
+    let key = TxRow::filter_full(&txid);
+    let value = store.get(&key)?;
+    Some(TxRow::from_row(&Row { key, value }))
+}
+
+pub fn txrows_by_prefix(store: &dyn ReadStore, txid_prefix: HashPrefix) -> Vec<TxRow> {
+    store
+        .scan(&TxRow::filter_prefix(txid_prefix))
+        .iter()
+        .map(|row| TxRow::from_row(row))
+        .collect()
+}
+
+pub fn txoutrows_by_script_hash(store: &dyn ReadStore, script_hash: &[u8]) -> Vec<TxOutRow> {
+    store
+        .scan(&TxOutRow::filter(script_hash))
+        .iter()
+        .map(|row| TxOutRow::from_row(row))
+        .collect()
+}
+
+pub fn txids_by_funding_output(
+    store: &dyn ReadStore,
+    txn_id: &Txid,
+    output_index: usize,
+) -> Vec<HashPrefix> {
+    store
+        .scan(&TxInRow::filter(&txn_id, output_index))
+        .iter()
+        .map(|row| TxInRow::from_row(row).txid_prefix)
+        .collect()
+}
+
+/// Mempool parameter is optional if it's known that the transaction is
+/// confired.
+pub fn txoutrow_to_fundingoutput(
+    store: &dyn ReadStore,
+    txoutrow: &TxOutRow,
+    mempool: Option<&Tracker>,
+    txquery: &TxQuery,
+    timeout: &TimeoutTrigger,
+) -> Result<FundingOutput> {
+    let txrow = lookup_tx_by_outrow(store, txoutrow, txquery, timeout)?;
+    let txid = txrow.get_txid();
+
+    Ok(FundingOutput {
+        txn_id: txid,
+        height: txrow.height,
+        output_index: txoutrow.get_output_index() as usize,
+        value: txoutrow.get_output_value(),
+        state: confirmation_state(mempool, &txid, txrow.height),
+    })
+}
+
+/// Lookup txrow using txid prefix, filter on output when there are
+/// multiple matches.
+fn lookup_tx_by_outrow(
+    store: &dyn ReadStore,
+    txout: &TxOutRow,
+    txquery: &TxQuery,
+    timeout: &TimeoutTrigger,
+) -> Result<TxRow> {
+    let mut txrows = txrows_by_prefix(store, txout.txid_prefix);
+    if txrows.len() == 1 {
+        return Ok(txrows.remove(0));
+    }
+    for txrow in txrows {
+        timeout.check()?;
+        let tx = txquery.get(&txrow.get_txid(), None, Some(txrow.height))?;
+        if txn_has_output(&tx, txout.get_output_index(), txout.key.script_hash_prefix) {
+            return Ok(txrow);
+        }
+    }
+    Err("tx not in store".into())
+}
+
+fn txn_has_output(txn: &Transaction, n: u64, scripthash_prefix: HashPrefix) -> bool {
+    let n = n as usize;
+    if txn.output.len() - 1 < n {
+        return false;
+    }
+    let hash = compute_script_hash(&txn.output[n].script_pubkey[..]);
+    hash_prefix(&hash) == scripthash_prefix
+}
+
+fn confirmation_state(mempool: Option<&Tracker>, txid: &Txid, height: u32) -> ConfirmationState {
+    // If mempool parameter is not passed, this implies that it is known
+    // that the transaction is confirmed.
+    if mempool.is_none() || height != MEMPOOL_HEIGHT {
+        return ConfirmationState::Confirmed;
+    }
+    let mempool = mempool.unwrap();
+    mempool.tx_confirmation_state(&txid, height)
+}
+
+pub fn find_spending_input(
+    store: &dyn ReadStore,
+    funding: &FundingOutput,
+    mempool: Option<&Tracker>,
+    txquery: &TxQuery,
+    timeout: &TimeoutTrigger,
+) -> Result<Option<SpendingInput>> {
+    let spending_txns = txids_by_funding_output(store, &funding.txn_id, funding.output_index);
+
+    if spending_txns.len() == 1 {
+        let spender_txid = &spending_txns[0];
+        let txrows = txrows_by_prefix(store, *spender_txid);
+        if txrows.len() == 1 {
+            // One match, assume it's correct to avoid load_txn lookup.
+            let txid = txrows[0].get_txid();
+            return Ok(Some(SpendingInput {
+                txn_id: txid,
+                height: txrows[0].height,
+                funding_output: (funding.txn_id, funding.output_index),
+                value: funding.value,
+                state: confirmation_state(mempool, &txid, txrows[0].height),
+            }));
+        }
+    }
+
+    // ambiguity, fetch from bitcoind to verify
+    let spending_txns: Vec<TxnHeight> = load_txns_by_prefix(
+        store,
+        txids_by_funding_output(store, &funding.txn_id, funding.output_index),
+        txquery,
+    )?;
+    let mut spending_inputs = vec![];
+    for t in &spending_txns {
+        for input in t.txn.input.iter() {
+            if input.previous_output.txid == funding.txn_id
+                && input.previous_output.vout == funding.output_index as u32
+            {
+                spending_inputs.push(SpendingInput {
+                    txn_id: t.txn.txid(),
+                    height: t.height,
+                    funding_output: (funding.txn_id, funding.output_index),
+                    value: funding.value,
+                    state: confirmation_state(mempool, &t.txn.txid(), t.height),
+                })
+            }
+        }
+        timeout.check()?;
+    }
+    assert!(spending_inputs.len() <= 1);
+    Ok(if spending_inputs.len() == 1 {
+        Some(spending_inputs.remove(0))
+    } else {
+        None
+    })
+}
+
+pub fn load_txns_by_prefix(
+    store: &dyn ReadStore,
+    prefixes: Vec<HashPrefix>,
+    txquery: &TxQuery,
+) -> Result<Vec<TxnHeight>> {
+    let mut txns = vec![];
+    for txid_prefix in prefixes {
+        for tx_row in txrows_by_prefix(store, txid_prefix) {
+            let txid: Txid = deserialize(&tx_row.key.txid).unwrap();
+            let txn = txquery.get(&txid, None, Some(tx_row.height))?;
+            txns.push(TxnHeight {
+                txn,
+                height: tx_row.height,
+            })
+        }
+    }
+    Ok(txns)
+}

--- a/src/query/tx.rs
+++ b/src/query/tx.rs
@@ -1,0 +1,67 @@
+use crate::cache::TransactionCache;
+use crate::daemon::Daemon;
+use crate::errors::*;
+use crate::query::header::HeaderQuery;
+use bitcoincash::blockdata::transaction::Transaction;
+use bitcoincash::consensus::deserialize;
+use bitcoincash::hash_types::{BlockHash, Txid};
+use serde_json::Value;
+use std::sync::Arc;
+
+pub struct TxQuery {
+    tx_cache: TransactionCache,
+    daemon: Daemon,
+    header: Arc<HeaderQuery>,
+    duration: Arc<prometheus::HistogramVec>,
+}
+
+impl TxQuery {
+    pub fn new(
+        tx_cache: TransactionCache,
+        daemon: Daemon,
+        header: Arc<HeaderQuery>,
+        duration: Arc<prometheus::HistogramVec>,
+    ) -> TxQuery {
+        TxQuery {
+            tx_cache,
+            daemon,
+            header,
+            duration,
+        }
+    }
+
+    pub fn get(
+        &self,
+        txid: &Txid,
+        blockhash: Option<&BlockHash>,
+        blockheight: Option<u32>,
+    ) -> Result<Transaction> {
+        let _timer = self.duration.with_label_values(&["load_txn"]).start_timer();
+        if let Some(tx) = self.tx_cache.get(txid) {
+            return Ok(tx);
+        }
+        let hash: Option<BlockHash> = match blockhash {
+            Some(hash) => Some(*hash),
+            None => match self.header.get_by_txid(txid, blockheight) {
+                Ok(header) => header.map(|h| *h.hash()),
+                Err(_) => None,
+            },
+        };
+        self.load_txn_from_bitcoind(txid, hash.as_ref())
+    }
+
+    fn load_txn_from_bitcoind(
+        &self,
+        txid: &Txid,
+        blockhash: Option<&BlockHash>,
+    ) -> Result<Transaction> {
+        let value: Value = self
+            .daemon
+            .gettransaction_raw(txid, blockhash, /*verbose*/ false)?;
+        let value_hex: &str = value.as_str().chain_err(|| "non-string tx")?;
+        let serialized_tx = hex::decode(&value_hex).chain_err(|| "non-hex tx")?;
+        let tx = deserialize(&serialized_tx).chain_err(|| "failed to parse serialized tx")?;
+        self.tx_cache.put(txid, serialized_tx);
+        Ok(tx)
+    }
+}

--- a/src/query/unconfirmed.rs
+++ b/src/query/unconfirmed.rs
@@ -1,0 +1,103 @@
+use crate::errors::*;
+use crate::mempool::Tracker;
+use crate::query::primitives::{FundingOutput, SpendingInput};
+use crate::query::queryutil::{
+    find_spending_input, txoutrow_to_fundingoutput, txoutrows_by_script_hash,
+};
+use crate::query::tx::TxQuery;
+use crate::scripthash::FullHash;
+use crate::timeout::TimeoutTrigger;
+use bitcoincash::hash_types::Txid;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct UnconfirmedQuery {
+    txquery: Arc<TxQuery>,
+    duration: Arc<prometheus::HistogramVec>,
+}
+
+impl UnconfirmedQuery {
+    pub fn new(txquery: Arc<TxQuery>, duration: Arc<prometheus::HistogramVec>) -> UnconfirmedQuery {
+        UnconfirmedQuery { txquery, duration }
+    }
+
+    pub fn get_funding(
+        &self,
+        tracker: &Tracker,
+        scripthash: &FullHash,
+        timeout: &TimeoutTrigger,
+    ) -> Result<Vec<FundingOutput>> {
+        let timer = self
+            .duration
+            .with_label_values(&["mempool_status_funding"])
+            .start_timer();
+        let funding = txoutrows_by_script_hash(tracker.index(), scripthash);
+        let funding: Result<Vec<FundingOutput>> = funding
+            .iter()
+            .map(|outrow| {
+                txoutrow_to_fundingoutput(
+                    tracker.index(),
+                    outrow,
+                    Some(tracker),
+                    &*self.txquery,
+                    timeout,
+                )
+            })
+            .collect();
+        timer.observe_duration();
+        funding
+    }
+
+    /// Get unconfirmed use of input spending from scripthash destination.
+    ///
+    /// unconfirmed_funding is obtain by calling self.get_funding,
+    /// confirmed_funding is obtained by calling ConfirmedQuery::get_funding
+    pub fn get_spending(
+        &self,
+        tracker: &Tracker,
+        unconfirmed_funding: &[FundingOutput],
+        confirmed_funding: &[FundingOutput],
+        timeout: &TimeoutTrigger,
+    ) -> Result<Vec<SpendingInput>> {
+        let timer = self
+            .duration
+            .with_label_values(&["mempool_status_spending"])
+            .start_timer();
+        let mut spending = vec![];
+
+        for funding_output in unconfirmed_funding.iter().chain(confirmed_funding.iter()) {
+            timeout.check()?;
+            if let Some(spent) = find_spending_input(
+                tracker.index(),
+                &funding_output,
+                Some(tracker),
+                &self.txquery,
+                timeout,
+            )? {
+                spending.push(spent);
+            }
+        }
+        timer.observe_duration();
+        Ok(spending)
+    }
+
+    /// Calculate fees for unconfirmed mempool transactions.
+    pub fn get_tx_fees(
+        &self,
+        tracker: &Tracker,
+        funding: &[FundingOutput],
+        spending: &[SpendingInput],
+    ) -> HashMap<Txid, u64> {
+        let mut txn_fees = HashMap::new();
+        for mempool_txid in funding
+            .iter()
+            .map(|f| f.txn_id)
+            .chain(spending.iter().map(|s| s.txn_id))
+        {
+            tracker
+                .get_fee(&mempool_txid)
+                .map(|fee| txn_fees.insert(mempool_txid, fee));
+        }
+        txn_fees
+    }
+}

--- a/src/rpc/blockchain.rs
+++ b/src/rpc/blockchain.rs
@@ -279,10 +279,10 @@ impl BlockchainRPC {
             None => false,
         };
         if !verbose {
-            let tx = self.query.load_txn(&tx_hash, None, None)?;
+            let tx = self.query.tx().get(&tx_hash, None, None)?;
             Ok(json!(hex::encode(serialize(&tx))))
         } else {
-            let header = self.query.lookup_blockheader(&tx_hash, None)?;
+            let header = self.query.header().get_by_txid(&tx_hash, None)?;
             let blocktime = match header {
                 Some(ref header) => header.header().time,
                 None => 0,
@@ -293,7 +293,7 @@ impl BlockchainRPC {
             };
             let confirmations = match header {
                 Some(ref header) => {
-                    if let Some(best) = self.query.best_header() {
+                    if let Some(best) = self.query.header().best() {
                         best.height() - header.height()
                     } else {
                         0
@@ -302,7 +302,7 @@ impl BlockchainRPC {
                 None => 0,
             };
             let blockhash = header.map(|h| *h.hash());
-            let tx = self.query.load_txn(&tx_hash, blockhash.as_ref(), None)?;
+            let tx = self.query.tx().get(&tx_hash, blockhash.as_ref(), None)?;
 
             let tx_serialized = serialize(&tx);
             Ok(json!({

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -494,7 +494,7 @@ impl RPC {
         txid: &Txid,
         blockhash: Option<&BlockHash>,
     ) -> Result<Vec<FullHash>> {
-        let txn = self.query.load_txn(txid, blockhash, None)?;
+        let txn = self.query.tx().get(txid, blockhash, None)?;
         let mut scripthashes = get_output_scripthash(&txn, None);
 
         for txin in txn.input {
@@ -504,7 +504,7 @@ impl RPC {
             let id: &Txid = &txin.previous_output.txid;
             let n = txin.previous_output.vout as usize;
 
-            let txn = self.query.load_txn(&id, None, None)?;
+            let txn = self.query.tx().get(&id, None, None)?;
             scripthashes.extend(get_output_scripthash(&txn, Some(n)));
         }
         Ok(scripthashes)

--- a/src/rpc/scripthash.rs
+++ b/src/rpc/scripthash.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
 use crate::mempool::MEMPOOL_HEIGHT;
-use crate::query::FundingOutput;
+use crate::query::primitives::FundingOutput;
 use crate::query::{Query, Status};
 use crate::scripthash::{FullHash, ToLEHex};
 use crate::timeout::TimeoutTrigger;
@@ -99,7 +99,7 @@ pub fn listunspent(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query::ConfirmationState;
+    use crate::mempool::ConfirmationState;
     use bitcoincash::hash_types::Txid;
     use bitcoincash::hashes::hex::FromHex;
     use serde_json::from_str;


### PR DESCRIPTION
The query class has grown rather large. This is mainly moving
responsibility out of the class into smaller isolated classes.

The decoupling of responsibilities will make it easier to implement
(scripthash|blockchain).get_mempool as it allows for easier code reuse.

## Test plan

`cargo test && ./contrib/run_functional_tests.sh`