### PR TITLE
Remove batch fetching of unconfirmed transactions 

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -561,21 +561,6 @@ impl Daemon {
         Ok(self.request("getrawtransaction", args)?)
     }
 
-    pub fn gettransactions(&self, txhashes: &[&Txid]) -> Result<Vec<Transaction>> {
-        let params_list: Vec<Value> = txhashes
-            .iter()
-            .map(|txhash| json!([txhash.to_hex(), /*verbose=*/ false]))
-            .collect();
-
-        let values = self.requests("getrawtransaction", &params_list)?;
-        let mut txs = vec![];
-        for value in values {
-            txs.push(tx_from_value(value)?);
-        }
-        assert_eq!(txhashes.len(), txs.len());
-        Ok(txs)
-    }
-
     pub fn getmempooltxids(&self) -> Result<HashSet<Txid>> {
         let txids: Value = self.request("getrawmempool", json!([/*verbose=*/ false]))?;
         let mut result = HashSet::new();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -397,7 +397,10 @@ impl Query {
             .duration
             .with_label_values(&["update_mempool"])
             .start_timer();
-        self.tracker.write().unwrap().update(self.app.daemon())
+        self.tracker
+            .write()
+            .unwrap()
+            .update(self.app.daemon(), self.tx())
     }
 
     /// Returns [vsize, fee_rate] pairs (measured in vbytes and satoshis).

--- a/src/query/tx.rs
+++ b/src/query/tx.rs
@@ -50,6 +50,18 @@ impl TxQuery {
         self.load_txn_from_bitcoind(txid, hash.as_ref())
     }
 
+    /// Get an transaction known to be unconfirmed.
+    ///
+    /// This is slightly faster that `get` as it avoids blockhash lookup. May
+    /// or may not return the transaction even if it is confirmed.
+    pub fn get_unconfirmed(&self, txid: &Txid) -> Result<Transaction> {
+        if let Some(tx) = self.tx_cache.get(txid) {
+            Ok(tx)
+        } else {
+            self.load_txn_from_bitcoind(txid, None)
+        }
+    }
+
     fn load_txn_from_bitcoind(
         &self,
         txid: &Txid,


### PR DESCRIPTION
There is no upper limit set on how many are batched, or how big they are. In
addition there is the unnecessary copying and logic support this.

By using the TxQuery class, all new mempool transactions are now put
into the transaction cache.

## Test plan
`cargo test && ./contrib/run_functional_tests.py`