### PR TITLE
Improve likeness with bitcoind getrawtransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "protobuf",
  "rand",
  "rocksdb",
+ "rust_decimal",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1376,6 +1377,16 @@ name = "roff"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
+
+[[package]]
+name = "rust_decimal"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ version-compare = "0.0.10"
 bitcoincash-addr = "0.5.1"
 indexmap = "1.6.0"
 rand = "0.7.3"
+rust_decimal = { version = "1.8.1", features = ["serde-float"] }
 
 [build-dependencies]
 configure_me_codegen = "0.3.12"

--- a/src/def.rs
+++ b/src/def.rs
@@ -3,3 +3,4 @@ pub const PROTOCOL_VERSION_MIN: &str = "1.4";
 pub const PROTOCOL_VERSION_MAX: &str = "1.4.3";
 pub const PROTOCOL_HASH_FUNCTION: &str = "sha256";
 pub const DATABASE_VERSION: &str = "1.1";
+pub const COIN: u64 = 100_000_000;

--- a/src/query/tx.rs
+++ b/src/query/tx.rs
@@ -1,12 +1,49 @@
 use crate::cache::TransactionCache;
 use crate::daemon::Daemon;
+use crate::def::COIN;
 use crate::errors::*;
 use crate::query::header::HeaderQuery;
+use bitcoincash::blockdata::script::Script;
 use bitcoincash::blockdata::transaction::Transaction;
-use bitcoincash::consensus::deserialize;
+use bitcoincash::consensus::encode::{deserialize, serialize};
 use bitcoincash::hash_types::{BlockHash, Txid};
+use bitcoincash::hashes::hex::ToHex;
+use bitcoincash::network::constants::Network;
+use bitcoincash::util::address::{Address, AddressType};
+use rust_decimal::prelude::*;
 use serde_json::Value;
 use std::sync::Arc;
+
+///  String returned is intended to be the same as produced by bitcoind
+///  GetTxnOutputType
+fn get_address_type(script: &Script) -> Option<&str> {
+    if script.is_op_return() {
+        return Some("nulldata");
+    }
+    let address = Address::from_script(script, Network::Bitcoin)?;
+    let address_type = address.address_type();
+    match address_type {
+        Some(AddressType::P2pkh) => Some("pubkeyhash"),
+        Some(AddressType::P2sh) => Some("scripthash"),
+        _ => {
+            if !address.is_standard() {
+                Some("nonstandard")
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn value_from_amount(amount: u64) -> Value {
+    if amount == 0 {
+        return json!(0.0);
+    }
+    let satoshis = Decimal::new(amount as i64, 0);
+    // rust-decimal crate with feature 'serde-float' should make this work
+    // without introducing precision errors
+    json!(satoshis.checked_div(Decimal::new(COIN as i64, 0)).unwrap())
+}
 
 pub struct TxQuery {
     tx_cache: TransactionCache,
@@ -60,6 +97,69 @@ impl TxQuery {
         } else {
             self.load_txn_from_bitcoind(txid, None)
         }
+    }
+
+    pub fn get_verbose(&self, txid: &Txid) -> Result<Value> {
+        let header = self.header.get_by_txid(&txid, None)?;
+        let blocktime = match header {
+            Some(ref header) => header.header().time,
+            None => 0,
+        };
+        let height = match header {
+            Some(ref header) => header.height(),
+            None => 0,
+        };
+        let confirmations = match header {
+            Some(ref header) => {
+                if let Some(best) = self.header.best() {
+                    best.height() - header.height()
+                } else {
+                    0
+                }
+            }
+            None => 0,
+        };
+        let blockhash = if let Some(h) = header {
+            Some(*h.hash())
+        } else {
+            None
+        };
+        let tx = self.get(txid, blockhash.as_ref(), None)?;
+        let tx_serialized = serialize(&tx);
+        Ok(json!({
+            "blockhash": blockhash.unwrap_or_default().to_hex(),
+            "blocktime": blocktime,
+            "height": height,
+            "confirmations": confirmations,
+            "hash": tx.txid().to_hex(),
+            "txid": tx.txid().to_hex(),
+            "size": tx_serialized.len(),
+            "hex": hex::encode(tx_serialized),
+            "locktime": tx.lock_time,
+            "time": blocktime,
+            "version": tx.version,
+            "vin": tx.input.iter().map(|txin| json!({
+                // bitcoind adds scriptSig hex as 'coinbase' when the transaction is a coinbase
+                "coinbase": if tx.is_coin_base() { Some(txin.script_sig.to_hex()) } else { None },
+                "sequence": txin.sequence,
+                "txid": txin.previous_output.txid.to_hex(),
+                "vout": txin.previous_output.vout,
+                "scriptSig": {
+                    "asm": txin.script_sig.asm(),
+                    "hex": txin.script_sig.to_hex(),
+                },
+            })).collect::<Vec<Value>>(),
+            "vout": tx.output.iter().enumerate().map(|(n, txout)| json!({
+                    "value_satoshi": txout.value,
+                    "value_coin": value_from_amount(txout.value),
+                    "n": n,
+                    "scriptPubKey": {
+                        "asm": txout.script_pubkey.asm(),
+                        "hex": txout.script_pubkey.to_hex(),
+                        "type": get_address_type(&txout.script_pubkey).unwrap_or_default(),
+                    },
+                    })).collect::<Vec<Value>>(),
+        }))
     }
 
     fn load_txn_from_bitcoind(

--- a/src/rpc/blockchain.rs
+++ b/src/rpc/blockchain.rs
@@ -282,51 +282,7 @@ impl BlockchainRPC {
             let tx = self.query.tx().get(&tx_hash, None, None)?;
             Ok(json!(hex::encode(serialize(&tx))))
         } else {
-            let header = self.query.header().get_by_txid(&tx_hash, None)?;
-            let blocktime = match header {
-                Some(ref header) => header.header().time,
-                None => 0,
-            };
-            let height = match header {
-                Some(ref header) => header.height(),
-                None => 0,
-            };
-            let confirmations = match header {
-                Some(ref header) => {
-                    if let Some(best) = self.query.header().best() {
-                        best.height() - header.height()
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            };
-            let blockhash = header.map(|h| *h.hash());
-            let tx = self.query.tx().get(&tx_hash, blockhash.as_ref(), None)?;
-
-            let tx_serialized = serialize(&tx);
-            Ok(json!({
-                "blockhash": blockhash.unwrap_or_default().to_hex(),
-                "blocktime": blocktime,
-                "height": height,
-                "confirmations": confirmations,
-                "hash": tx.txid().to_hex(),
-                "txid": tx.txid().to_hex(),
-                "size": tx_serialized.len(),
-                "hex": hex::encode(tx_serialized),
-                "locktime": tx.lock_time,
-                "time": blocktime,
-                "vin": tx.input.iter().map(|txin| json!({
-                    "sequence": txin.sequence,
-                    "txid": txin.previous_output.txid.to_hex(),
-                    "vout": txin.previous_output.vout,
-                    "scriptSig": txin.script_sig.to_hex(),
-                })).collect::<Vec<Value>>(),
-                "vout": tx.output.iter().map(|txout| json!({
-                    "value": txout.value,
-                    "scriptPubKey": txout.script_pubkey.to_hex()
-                })).collect::<Vec<Value>>(),
-            }))
+            self.query.tx().get_verbose(&tx_hash)
         }
     }
 


### PR DESCRIPTION
The electrum specification for verbose transaction is as follows:

> The result is a coin-specific dictionary – whatever the coin daemon returns when asked for a verbose form of the raw transaction.

In other words, it's undefined. In addition the performance of fetching the details from bitcoind is much worse that just creating it ourselves, as we can do so from the data in our transaction cache. This is also what ElectrsCash does.

This PR makes the output more like what we'd expect from any bitcoind, be it BU, BCHN or others. This is a breaking change.

The following changes have been made:

* `txout -> value` should not return satoshis, but as coins (`/ 100 000 000`). However, just changing the unit is dangerous, as we don't know what applications expect satoshis now. It's better to break these by removing the field. This field has been split into `txout -> value_satoshi` and `txout -> value_coin`. The `value` field is scheduled to be re-added in 6 months.
* `txout -> scriptPubKey` is now an object with fields `hex`, `asm` and `type`, rather than a hex string.
* `txout -> n` is added.
* `txin -> scriptSig` is now an object with fields `hex` and `asm`

### Test plan

* Test added to [elecrum_transaction_get.py](https://gitlab.com/bitcoinunlimited/BCHUnlimited/-/merge_requests/2388)
* `./contrib/run_functional_tests.sh`

Thanks to Sahid Miller from electrum-cash telegram for reporting incompatibility issues.