### PR TITLE
Change semantics of index-batch-size

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -95,7 +95,7 @@ default = "5"
 [[param]]
 name = "index_batch_size"
 type = "usize"
-doc = "Number of blocks to get in one JSONRPC request from bitcoind"
+doc = "Buffer size for blocks (# of blocks) fetched via RPC from bitcoind"
 default = "100"
 
 [[param]]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -523,19 +523,6 @@ impl Daemon {
             .get_or_else(&blockhash, || self.load_blocktxids(blockhash))
     }
 
-    pub fn getblocks(&self, blockhashes: &[BlockHash]) -> Result<Vec<Block>> {
-        let params_list: Vec<Value> = blockhashes
-            .iter()
-            .map(|hash| json!([hash.to_hex(), /*verbose=*/ false]))
-            .collect();
-        let values = self.requests("getblock", &params_list)?;
-        let mut blocks = vec![];
-        for value in values {
-            blocks.push(block_from_value(value)?);
-        }
-        Ok(blocks)
-    }
-
     pub fn gettransaction(
         &self,
         txhash: &Txid,


### PR DESCRIPTION
The old semantics is to request 'index-batch-size' number of blocks in
one RPC request.

This sometimes causes a very large peak memory usage in bitcoind, as
index-batch-size number of potentially 32MB blocks need to be serialized as
JSON in one request. See issue #3.

The new semantics is add a sync buffer of size 'index-batch-size' to the
electrum server and continuously try to fill the buffer by fetching one
block at a time.

### Test plan

Full reindex of mainnet. Observe performance is not noticably impacted.

At around block height 360k, performance is at > 20 blocks/s.
```
$ tail -f debug.log | grep --line-buffered getblock | pv --line-mode -b --average-rate --rate > /dev/null
0.8k [18,7 /s] [20,7 /s]

(Requires with `debug=rpc` in `bitcoin.conf`)
```