### PR TITLE
Use parallel iter for finding inputs/outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "rand",
+ "rayon",
  "rocksdb",
  "rust_decimal",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ indexmap = "1.6.0"
 rand = "0.7.3"
 rust_decimal = { version = "1.8.1", features = ["serde-float"] }
 genawaiter = "0.99.1"
+rayon = "1.5.0"
 
 [build-dependencies]
 configure_me_codegen = "0.3.12"

--- a/src/query/queryutil.rs
+++ b/src/query/queryutil.rs
@@ -10,8 +10,7 @@ use crate::util::{hash_prefix, HashPrefix};
 use bitcoincash::blockdata::transaction::Transaction;
 use bitcoincash::consensus::encode::deserialize;
 use bitcoincash::hash_types::Txid;
-use genawaiter::sync::gen;
-use genawaiter::yield_;
+use genawaiter::{sync::gen, yield_};
 
 // TODO: the functions below can be part of ReadStore.
 pub fn txrow_by_txid(store: &dyn ReadStore, txid: &Txid) -> Option<TxRow> {
@@ -133,6 +132,9 @@ pub fn find_spending_input(
                 state: confirmation_state(mempool, &txid, txrows[0].height),
             }));
         }
+    }
+    if spending_txns.is_empty() {
+        return Ok(None);
     }
 
     // Ambiguity, fetch from bitcoind to verify


### PR DESCRIPTION
Finding inputs/outputs for get history calls is CPU intensive. Use
parallel iter to speed up the query.

Simple benchmarking shows 3x speedup on my laptop for large histories,
such as the eatbch address.

### Test plan 
Run the following with and without this change. This is the eatbch address which has about 13k transactions associated with it.
```
contrib % time python3 client.py --server localhost blockchain.address.get_history bitcoincash:pp8skudq3x5hzw8ew7vzsw8tn4k8wxsqsv0lt0mf3g > /dev/null
```

On my laptop, with this change
`0.07s user 0.03s system 5% cpu 1.721 total`

Without this change:
`0.07s user 0.02s system 1% cpu 4.885 total`