### PR TITLE
Handle send error at connect

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -376,7 +376,10 @@ impl RPC {
                 stream
                     .set_nonblocking(false)
                     .expect("failed to set connection as blocking");
-                acceptor.send(Some((stream, addr))).expect("send failed");
+                match acceptor.send(Some((stream, addr))) {
+                    Ok(_) => {}
+                    Err(e) => trace!("Failed to send to client {:?}", e),
+                }
             }
         });
         chan


### PR DESCRIPTION
Fixes issue found by @sickpig

```
2021-02-16 11:30:49 Electrum: TRACE - joining ThreadId(1954378)
2021-02-16 11:30:49 Electrum: TRACE - joining ThreadId(1954340)
2021-02-16 11:30:49 Electrum: INFO - RPC connections are closed
2021-02-16 11:30:49 Electrum: TRACE - RPC server is stopped
2021-02-16 11:30:49 Electrum: thread 'acceptor' panicked at 'send failed: "SendError(..)"', src/rpc/mod.rs:379:53
2021-02-16 11:30:49 Electrum: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-02-16 11:30:50 Electrum: TRACE - closing DB at "/home/sickpig/.bitcoin/electrscash/mainnet"
2021-02-16 11:30:50 Electrum: TRACE - done closing db
```

#### Test plan:
`./contrib/run_functional_tests.sh`
