### PR TITLE
Use 'OutPoint' from the bitcoincash crate

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -1,4 +1,5 @@
 use bitcoincash::blockdata::block::{Block, BlockHeader};
+use bitcoincash::blockdata::transaction::OutPoint;
 use bitcoincash::blockdata::transaction::{Transaction, TxIn, TxOut};
 use bitcoincash::consensus::encode::{deserialize, serialize};
 use bitcoincash::hash_types::{BlockHash, Txid};
@@ -43,11 +44,11 @@ impl TxInRow {
         }
     }
 
-    pub fn filter(txid: &Txid, output_index: usize) -> Bytes {
+    pub fn filter(prevout: &OutPoint) -> Bytes {
         bincode::serialize(&TxInKey {
             code: b'I',
-            prev_hash_prefix: hash_prefix(&txid[..]),
-            prev_index: encode_varint(output_index as u64),
+            prev_hash_prefix: hash_prefix(&prevout.txid[..]),
+            prev_index: encode_varint(prevout.vout as u64),
         })
         .unwrap()
     }
@@ -120,8 +121,8 @@ impl TxOutRow {
         bincode::deserialize(&row.key).expect("failed to parse TxOutRow key")
     }
 
-    pub fn get_output_index(&self) -> u64 {
-        decode_varint(&self.output_index)
+    pub fn get_output_index(&self) -> u32 {
+        decode_varint(&self.output_index) as u32
     }
 
     pub fn get_output_value(&self) -> u64 {

--- a/src/query/primitives.rs
+++ b/src/query/primitives.rs
@@ -1,15 +1,13 @@
 use crate::mempool::ConfirmationState;
+use bitcoincash::blockdata::transaction::OutPoint;
 use bitcoincash::hash_types::Txid;
 
 pub struct FundingOutput {
-    pub txn_id: Txid,
+    pub funding_output: OutPoint,
     pub height: u32,
-    pub output_index: usize,
     pub value: u64,
     pub state: ConfirmationState,
 }
-
-pub type OutPoint = (Txid, usize); // (txid, output_index)
 
 pub struct SpendingInput {
     pub txn_id: Txid,

--- a/src/query/unconfirmed.rs
+++ b/src/query/unconfirmed.rs
@@ -91,7 +91,7 @@ impl UnconfirmedQuery {
         let mut txn_fees = HashMap::new();
         for mempool_txid in funding
             .iter()
-            .map(|f| f.txn_id)
+            .map(|f| f.funding_output.txid)
             .chain(spending.iter().map(|s| s.txn_id))
         {
             tracker

--- a/src/rpc/scripthash.rs
+++ b/src/rpc/scripthash.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 fn unspent_to_json(out: &FundingOutput) -> Value {
     json!({
         "height": if out.height == MEMPOOL_HEIGHT { 0 } else { out.height },
-        "tx_pos": out.output_index,
-        "tx_hash": out.txn_id.to_hex(),
+        "tx_pos": out.funding_output.vout,
+        "tx_hash": out.funding_output.txid.to_hex(),
         "value": out.value,
     })
 }
@@ -116,6 +116,7 @@ pub fn listunspent(
 mod tests {
     use super::*;
     use crate::mempool::ConfirmationState;
+    use bitcoincash::blockdata::transaction::OutPoint;
     use bitcoincash::hash_types::Txid;
     use bitcoincash::hashes::hex::FromHex;
     use serde_json::from_str;
@@ -130,9 +131,8 @@ mod tests {
 
     fn create_out(height: u32, txn_id: Txid) -> FundingOutput {
         FundingOutput {
-            txn_id,
+            funding_output: OutPoint::new(txn_id, 0),
             height,
-            output_index: 0,
             value: 2020,
             state: ConfirmationState::InMempool,
         }


### PR DESCRIPTION
This removes our own OutPoint type alias, switching all use to the
OutPoint struct in the bitcoincash crate.

#### Test plan

`cargo test && ./contrib/functional_tests.sh`