### PR TITLE
Add `blockchain.utxo.get`

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -3,51 +3,90 @@
 See the [Electrum Cash Protocol specification](https://bitcoincash.network/electrum/)
 for "offical" supported RPC methods.
 
-## Known deviations
+## Extensions
 
-## blockchain.transcation.get
+In addition to the above supported RPC methods, ElectrsCash implements the following extensions.
 
-The output for `verbose = true` is implemented in ElectrsCash. The output for
-this call is always consistent, regardless of what full node implementation
-is used for backend.
+### blockchain.address.get\_first\_use
 
-If there are breaking changes to this output in the future, this will be done
-as part of a major version release of ElectrsCash, meaning first digit of
-version number will be increased.
+See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
 
-## blockchain.transaction.get_merkle
+### blockchain.scripthash.get\_first\_use
+
+See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
+
+### blockchain.transaction.get\_merkle
 
 The `height` parameter is optional with ElectrsCash. If omitted, ElectrsCash
 uses its internal index to lookup the transaction height.
 
-## Extensions
-
-In addition, the following RPC methods are supported.
-
-## blockchain.transaction.get\_confirmed\_blockhash
+### blockchain.transaction.get\_confirmed\_blockhash
 
 Returns the blockhash of a block the transaction confirmed in. Returns error
 if transaction is not confirmed (or does not exist).
 
 Signature: `blockchain.transaction.get_confirmed_blockhash(txid)`
 
-* txid - Transaction ID
+* `txid` - Transaction ID
 
-### Example result
+#### Example result
 ```
 'block_hash': '000000000000000002a04f56505ef459e1edd21fb3725524116fdaedf3a4d0ab',
 'block_height': 597843,
 ```
 
-## blockchain.address.get\_first\_use
+### blockchain.utxo.get
 
-See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
+Returns data on a specified output of specific transaction. Returns error
+if transaction or output does not exist.
 
-## blockchain.scripthash.get\_first\_use
+If the output is spent, information about the spender is provided. This allows
+a SPV client to call `blockchain.transaction.get_merkle` to generate a merkle
+branch, proving that it is spent.
 
-See [protocol extras](https://bitcoincash.network/electrum/protocol-methods-extra.html)
+Signature: `blockchain.utxo.get(tx_hash, output_index)`
 
-## cashaccount.query.name
+* `tx_hash` - Transaction ID
+* `output_index` - The vout position in the transaction.
+
+#### Result
+
+A dictionary with the following keys:
+
+* `state` - State of the utxo. A string that is "spent" or "unspent".
+
+* `height`- The height the utxo was confirmed in. If it is unconfirmed, the
+   value is 0 if all inputs are confirmed, and -1 otherwise.
+
+* `value` - The output’s value in minimum coin units (satoshis).
+
+* `scripthash` - The scriphash of the output scriptPubKey.
+
+* `spent` - The transaction spending the utxo with the following keys:
+
+    * `tx_pos` - The zero-based index of the input in the transaction’s list of inputs. Null if utxo is unspent.
+
+    * `tx_hash` - The transaction ID. Null if utxo is unspent.
+
+    * `height`- The height the transaction was confirmed in. If it is unconfirmed, the
+       value is 0 if all inputs are confirmed, and -1 otherwise. Null if utxo is unspent.
+
+#### Example result
+```
+{
+    "amount": 4999999000,
+    "height": 100000,
+    "scripthash": "2e6d15f1a36288b55d5cb14d21f00324cbf767b459dc37e5054e383e434e0b16",
+    "spent": {
+        "height": -1,
+        "tx_hash": "90adba10cdb91546b9c17e93ee300fe7940c6c3dda80f83bb791df5895d83aff",
+        "tx_pos": 0
+    },
+    "status": "spent"
+},
+```
+
+### cashaccount.query.name
 
 Signature: `blockchain.query.name(name, height)`
 
@@ -72,3 +111,15 @@ Result:
 'height': 563836,
 'tx': '0100000001bca903bbc429218234857628b382e8aa8e3bfa74c5b59628ad053284e50bf6ac010000006b4830450221009bbd0a96ef5ef33e09c4fce7fafd2add714ebe05d87a9cb6c826b863d0e99225022039d77b8bd9c8067636e64d6f1aeeeeb8b816bbc875afd04cef9eb299df83b7d64121037a291b1a7f21b03b2a5120434b7a06b61944e0edc1337c76d737d0b5fa1c871fffffffff020000000000000000226a040101010105646167757215018c092ec2cbd842e89432c7c53b54db3a958c83a575f00d00000000001976a914dfdd3e914d73fee85ad40cd71430327f0404c15488ac00000000'
 ```
+
+## Notable differences
+
+### blockchain.transcation.get
+
+The output for `verbose = true` is implemented in ElectrsCash. The output for
+this call is always consistent, regardless of what full node implementation
+is used for backend.
+
+If there are breaking changes to this output in the future, this will be done
+as part of a major version release of ElectrsCash, meaning first digit of
+version number will be increased.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,6 +63,8 @@ fn check_error_code(reply_obj: &Map<String, Value>, method: &str) -> Result<()> 
             match code {
                 // RPC_IN_WARMUP -> retry by later reconnection
                 -28 => bail!(ErrorKind::Connection(err.to_string())),
+                // RPC_INVALID_ADDRESS_OR_KEY
+                -5 => bail!(rpc_invalid_params(err.to_string())),
                 _ => bail!("{} RPC error: {}", method, err),
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,3 +41,7 @@ error_chain! {
 pub fn rpc_invalid_request(what: String) -> ErrorKind {
     ErrorKind::RpcError(RpcErrorCode::InvalidRequest, what)
 }
+
+pub fn rpc_invalid_params(what: String) -> ErrorKind {
+    ErrorKind::RpcError(RpcErrorCode::InvalidParams, what)
+}

--- a/src/query/header.rs
+++ b/src/query/header.rs
@@ -52,4 +52,14 @@ impl HeaderQuery {
     pub fn at_height(&self, height: usize) -> Option<HeaderEntry> {
         self.app.index().get_header(height)
     }
+
+    /// Get the height of block where a transaction was confirmed, or None if it's
+    /// not confirmed.
+    /// TODO: Move to TxQuery
+    pub fn get_confirmed_height_for_tx(&self, txid: &Txid) -> Option<u32> {
+        match txrow_by_txid(self.app.read_store(), txid) {
+            Some(txrow) => Some(txrow.height),
+            None => None,
+        }
+    }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -90,6 +90,10 @@ impl Status {
                 ConfirmationState::Confirmed => f.height as i32,
                 ConfirmationState::InMempool => 0,
                 ConfirmationState::UnconfirmedParent => -1,
+                ConfirmationState::Indeterminate => {
+                    debug_assert!(false, "ConfirmationState cannot be Indeterminate");
+                    0
+                }
             };
 
             txns_map.insert(f.funding_output.txid, height);
@@ -99,6 +103,10 @@ impl Status {
                 ConfirmationState::Confirmed => s.height as i32,
                 ConfirmationState::InMempool => 0,
                 ConfirmationState::UnconfirmedParent => -1,
+                ConfirmationState::Indeterminate => {
+                    debug_assert!(false, "ConfirmationState cannot be Indeterminate");
+                    0
+                }
             };
             txns_map.insert(s.txn_id, height as i32);
         }

--- a/src/query/unconfirmed.rs
+++ b/src/query/unconfirmed.rs
@@ -2,11 +2,14 @@ use crate::errors::*;
 use crate::mempool::Tracker;
 use crate::query::primitives::{FundingOutput, SpendingInput};
 use crate::query::queryutil::{
-    find_spending_input, txoutrow_to_fundingoutput, txoutrows_by_script_hash,
+    find_spending_input, get_tx_spending_prevout, txoutrow_to_fundingoutput,
+    txoutrows_by_script_hash,
 };
 use crate::query::tx::TxQuery;
 use crate::scripthash::FullHash;
 use crate::timeout::TimeoutTrigger;
+use bitcoincash::blockdata::transaction::OutPoint;
+use bitcoincash::blockdata::transaction::Transaction;
 use bitcoincash::hash_types::Txid;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -99,5 +102,21 @@ impl UnconfirmedQuery {
                 .map(|fee| txn_fees.insert(mempool_txid, fee));
         }
         txn_fees
+    }
+
+    pub fn get_tx_spending_prevout(
+        &self,
+        tracker: &Tracker,
+        timeout: &TimeoutTrigger,
+        prevout: &OutPoint,
+    ) -> Result<
+        Option<(
+            Transaction,
+            u32, /* input index */
+            u32, /* confirmation height */
+        )>,
+    > {
+        // TODO: Check if has unconfirmed parent
+        get_tx_spending_prevout(tracker.index(), &*self.txquery, timeout, prevout)
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -151,6 +151,7 @@ impl Connection {
             "blockchain.transaction.id_from_pos" => {
                 self.blockchainrpc.transaction_id_from_pos(&params)
             }
+            "blockchain.utxo.get" => self.blockchainrpc.utxo_get(&params, &timeout),
             "mempool.get_fee_histogram" => Ok(self.mempool_get_fee_histogram()),
             "server.add_peer" => server_add_peer(),
             "server.banner" => server_banner(&self.query),

--- a/src/rpc/parseutil.rs
+++ b/src/rpc/parseutil.rs
@@ -24,8 +24,9 @@ pub fn hash_from_value<T: Hash>(val: Option<&Value>) -> Result<T> {
     let hash = val.chain_err(|| rpc_arg_error("missing hash"))?;
     let hash = hash
         .as_str()
-        .chain_err(|| rpc_arg_error("non-string hash"))?;
-    let hash = T::from_hex(hash).chain_err(|| rpc_arg_error("non-hex hash"))?;
+        .chain_err(|| rpc_arg_error("expected hash argument to be a string"))?;
+    let hash = T::from_hex(hash)
+        .chain_err(|| rpc_arg_error("expected hash argument to be a hex string"))?;
     Ok(hash)
 }
 


### PR DESCRIPTION
Add RPC call `blockchain.utxo.get` with the following interface

```
{
   "state": "spent" || "unspent",
   "height":  height # height of the tx creating the utxo is confirmed in (0 for mempool, -1 if spender has unconfirmed parent)
   "value": value # value of utxo in satoshis
   "scripthash": scripthash # scriphash of the output scriptPubKey
   "spent": {
      "tx_hash": txid, # id of the tx spending the utxo
      "tx_pos": pos, # input index in the spending transaction
      "height": height # height of the block spender is confirmed in (0 for mempool, -1 if spender has unconfirmed parent)
   },
}
```