### PR TITLE
Bugfix/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.55.0-slim-buster
 RUN apt-get update \
   && apt-get install -y --no-install-recommends clang=1:7.* cmake=3.* \
-     libsnappy-dev=1.* curl \
+     libsnappy-dev=1.* curl make \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust:1.44.1-slim-buster
-
+FROM rust:1.55.0-slim-buster
 RUN apt-get update \
   && apt-get install -y --no-install-recommends clang=1:7.* cmake=3.* \
      libsnappy-dev=1.* curl \


### PR DESCRIPTION
fix docker build error due to out date rust version
similar issue and fix: https://github.com/ogham/dog/issues/26
 ``` bash
 > [7/7] RUN cargo install --path .:
   Installing electrscash v3.0.0 (/home/user)
     Updating crates.io index
  Downloading crates ...
   Downloaded cc v1.0.70
   Downloaded env_logger v0.8.4
   Downloaded page_size v0.4.2
   Downloaded num-integer v0.1.44
   Downloaded num_cpus v1.13.0
   Downloaded nom v6.1.2
   Downloaded memchr v2.4.1
   Downloaded autocfg v1.0.1
   Downloaded async-mutex v1.4.0
   Downloaded atomic-waker v1.0.0
   Downloaded blocking v1.0.2
   Downloaded addr2line v0.16.0
   Downloaded cache-padded v1.1.1
   Downloaded block-buffer v0.9.0
   Downloaded bitvec v0.19.5
   Downloaded concurrent-queue v1.2.2
   Downloaded futures-lite v1.12.0
   Downloaded paste-impl v0.1.18
   Downloaded libloading v0.7.0
   Downloaded pin-project-lite v0.2.7
   Downloaded lazycell v1.3.0
   Downloaded dirs-next v2.0.0
   Downloaded lazy_static v0.2.11
   Downloaded object v0.26.2
   Downloaded clang-sys v1.2.2
   Downloaded async-std v1.10.0
   Downloaded jemalloc-sys v0.3.2
   Downloaded async-global-executor v2.0.2
   Downloaded backtrace v0.3.61
   Downloaded cfg-if v0.1.10
   Downloaded cargo_toml v0.8.1
   Downloaded byteorder v1.4.3
   Downloaded bindgen v0.59.1
   Downloaded percent-encoding v1.0.1
   Downloaded cpufeatures v0.2.1
   Downloaded either v1.6.1
   Downloaded dirs-sys-next v0.1.2
   Downloaded digest v0.9.0
   Downloaded errno v0.2.7
   Downloaded futures-io v0.3.17
   Downloaded funty v1.1.0
   Downloaded error-chain v0.12.4
   Downloaded event-listener v2.5.1
   Downloaded getrandom v0.1.16
   Downloaded instant v0.1.10
   Downloaded jemalloc-ctl v0.3.3
   Downloaded hashbrown v0.11.2
   Downloaded gimli v0.25.0
   Downloaded kernel32-sys v0.2.2
   Downloaded lock_api v0.4.5
   Downloaded memoffset v0.6.4
   Downloaded miniz_oxide v0.4.4
   Downloaded num-traits v0.2.14
   Downloaded opaque-debug v0.3.0
   Downloaded libc v0.2.101
   Downloaded paste v0.1.18
   Downloaded parking v2.0.0
   Downloaded ppv-lite86 v0.2.10
   Downloaded pin-utils v0.1.0
   Downloaded polling v2.1.0
   Downloaded parking_lot_core v0.8.5
   Downloaded fmt2io v0.1.0
   Downloaded jobserver v0.1.24
   Downloaded man v0.1.1
   Downloaded hex v0.3.2
   Downloaded proc-macro-hack v0.5.19
   Downloaded peeking_take_while v0.1.2
   Downloaded parse_arg v0.1.4
   Downloaded librocksdb-sys v6.20.3
   Downloaded protobuf v2.14.0
   Downloaded rand_core v0.5.1
   Downloaded radium v0.5.3
   Downloaded ryu v1.0.5
   Downloaded rocksdb v0.15.0
   Downloaded proc-macro2 v1.0.29
   Downloaded proc-macro-error v0.4.12
   Downloaded regex-syntax v0.6.25
   Downloaded scopeguard v1.1.0
   Downloaded sha-1 v0.9.8
   Downloaded sha2 v0.9.8
   Downloaded rust_decimal v1.15.0
   Downloaded secp256k1 v0.19.0
   Downloaded secp256k1-sys v0.3.0
   Downloaded smallvec v1.6.1
   Downloaded strsim v0.8.0
   Downloaded termcolor v1.1.2
   Downloaded thiserror-impl v1.0.29
   Downloaded syn v1.0.76
   Downloaded syn-mid v0.5.3
   Downloaded chunked_transfer v0.3.1
   Downloaded thread_local v0.3.4
   Downloaded httpcodec v0.2.3
   Downloaded genawaiter-proc-macro v0.99.1
   Downloaded genawaiter-macro v0.99.1
   Downloaded bitcoincash-addr v0.5.2
   Downloaded proc-macro-error-attr v0.4.12
   Downloaded time v0.1.43
   Downloaded sysconf v0.3.4
   Downloaded tinyvec v1.3.1
   Downloaded tinyvec_macros v0.1.0
   Downloaded toml v0.4.10
   Downloaded tap v1.0.1
   Downloaded prometheus v0.11.0
   Downloaded textwrap v0.11.0
   Downloaded unicode-width v0.1.8
   Downloaded unicode-segmentation v1.8.0
   Downloaded vec_map v0.8.2
   Downloaded value-bag v1.0.0-alpha.7
   Downloaded which v3.1.1
   Downloaded wyz v0.2.0
   Downloaded winapi-build v0.1.1
   Downloaded waker-fn v1.1.0
   Downloaded void v1.0.2
   Downloaded serde_json v1.0.67
   Downloaded rand v0.7.3
   Downloaded version-compare v0.0.10
   Downloaded unicode-xid v0.2.2
   Downloaded unreachable v1.0.0
   Downloaded winapi v0.2.8
   Downloaded bitflags v1.3.2
   Downloaded tiny_http v0.6.4
   Downloaded bitcoin_hashes v0.9.7
   Downloaded bitcoincash v0.25.2
   Downloaded async-lock v2.4.0
   Downloaded trackable v0.2.24
   Downloaded unicode-normalization v0.1.19
   Downloaded unicode-bidi v0.3.6
   Downloaded trackable v1.2.0
   Downloaded version_check v0.9.3
   Downloaded url v1.7.2
   Downloaded unsigned-varint v0.2.3
   Downloaded genawaiter v0.99.1
   Downloaded typenum v1.14.0
   Downloaded trackable_derive v1.0.0
   Downloaded toml v0.5.8
   Downloaded thiserror v1.0.29
   Downloaded configure_me_codegen v0.3.14
   Downloaded bytecodec v0.4.15
   Downloaded bitcoin_hashes v0.7.6
   Downloaded cashaccount-sys v0.1.1
   Downloaded atty v0.2.11
   Downloaded configure_me v0.3.4
   Downloaded c_fixed_string v0.2.0
   Downloaded bech32 v0.7.3
   Downloaded ascii v0.8.7
   Downloaded stderrlog v0.4.3
   Downloaded socket2 v0.4.1
   Downloaded slab v0.4.4
   Downloaded signal-hook-registry v1.4.0
   Downloaded signal-hook v0.1.17
   Downloaded shlex v1.1.0
   Downloaded roff v0.1.0
   Downloaded regex v1.5.4
   Downloaded rayon-core v1.9.1
   Downloaded serde_derive v1.0.130
   Downloaded serde v1.0.130
   Downloaded rustc-hash v1.1.0
   Downloaded rustc-demangle v0.1.21
   Downloaded rand_chacha v0.2.2
   Downloaded quote v1.0.9
   Downloaded rayon v1.5.1
   Downloaded idna v0.1.5
   Downloaded base64 v0.10.1
   Downloaded lazy_static v1.4.0
   Downloaded glob v0.3.0
   Downloaded parking_lot v0.11.2
   Downloaded once_cell v1.8.0
   Downloaded crossbeam-utils v0.6.6
   Downloaded log v0.4.14
   Downloaded kv-log-macro v1.0.7
   Downloaded matches v0.1.9
   Downloaded crossbeam-channel v0.3.9
   Downloaded jemallocator v0.3.2
   Downloaded indexmap v1.7.0
   Downloaded itoa v0.4.8
   Downloaded humantime v2.1.0
   Downloaded generic-array v0.14.4
   Downloaded fastrand v1.5.0
   Downloaded fnv v1.0.7
   Downloaded futures-core v0.3.17
   Downloaded fs_extra v1.2.0
   Downloaded crossbeam-epoch v0.9.5
   Downloaded clap v2.33.3
   Downloaded crossbeam-utils v0.8.5
   Downloaded ctor v0.1.21
   Downloaded crossbeam-channel v0.5.1
   Downloaded chrono v0.4.19
   Downloaded cfg-if v1.0.0
   Downloaded bincode v1.3.3
   Downloaded async-task v4.0.3
   Downloaded async-io v1.6.0
   Downloaded ansi_term v0.11.0
   Downloaded arrayvec v0.5.2
   Downloaded adler v1.0.2
   Downloaded crossbeam-deque v0.8.1
   Downloaded cexpr v0.5.0
   Downloaded async-executor v1.4.1
   Downloaded async-channel v1.6.1
   Downloaded aho-corasick v0.7.18
    Compiling libc v0.2.101
    Compiling proc-macro2 v1.0.29
    Compiling version_check v0.9.3
    Compiling unicode-xid v0.2.2
    Compiling syn v1.0.76
    Compiling cfg-if v1.0.0
    Compiling autocfg v1.0.1
    Compiling memchr v2.4.1
    Compiling lazy_static v1.4.0
    Compiling log v0.4.14
    Compiling serde v1.0.130
    Compiling radium v0.5.3
    Compiling glob v0.3.0
    Compiling wyz v0.2.0
    Compiling funty v1.1.0
    Compiling regex-syntax v0.6.25
    Compiling tap v1.0.1
    Compiling unicode-width v0.1.8
    Compiling termcolor v1.1.2
    Compiling strsim v0.8.0
    Compiling futures-core v0.3.17
    Compiling humantime v2.1.0
    Compiling bitflags v1.3.2
    Compiling bindgen v0.59.1
    Compiling ansi_term v0.11.0
    Compiling vec_map v0.8.2
    Compiling lazycell v1.3.0
    Compiling crossbeam-utils v0.8.5
    Compiling rustc-hash v1.1.0
    Compiling shlex v1.1.0
    Compiling peeking_take_while v0.1.2
    Compiling proc-macro-hack v0.5.19
    Compiling cache-padded v1.1.1
    Compiling typenum v1.14.0
    Compiling serde_derive v1.0.130
    Compiling scopeguard v1.1.0
    Compiling fastrand v1.5.0
    Compiling pin-project-lite v0.2.7
    Compiling parking v2.0.0
    Compiling void v1.0.2
    Compiling waker-fn v1.1.0
    Compiling futures-io v0.3.17
    Compiling event-listener v2.5.1
    Compiling getrandom v0.1.16
    Compiling once_cell v1.8.0
    Compiling fs_extra v1.2.0
    Compiling crossbeam-epoch v0.9.5
    Compiling tinyvec_macros v0.1.0
    Compiling async-task v4.0.3
    Compiling roff v0.1.0
    Compiling slab v0.4.4
    Compiling rayon-core v1.9.1
    Compiling configure_me_codegen v0.3.14
    Compiling parking_lot_core v0.8.5
    Compiling winapi-build v0.1.1
    Compiling atomic-waker v1.0.0
    Compiling smallvec v1.6.1
    Compiling byteorder v1.4.3
    Compiling protobuf v2.14.0
    Compiling ryu v1.0.5
    Compiling fmt2io v0.1.0
    Compiling matches v0.1.9
    Compiling adler v1.0.2
    Compiling unicode-segmentation v1.8.0
    Compiling unicode-bidi v0.3.6
    Compiling gimli v0.25.0
    Compiling ppv-lite86 v0.2.10
    Compiling rustc-demangle v0.1.21
    Compiling prometheus v0.11.0
    Compiling percent-encoding v1.0.1
    Compiling serde_json v1.0.67
    Compiling winapi v0.2.8
    Compiling opaque-debug v0.3.0
    Compiling lazy_static v0.2.11
    Compiling cfg-if v0.1.10
    Compiling cpufeatures v0.2.1
    Compiling ascii v0.8.7
    Compiling bitcoin_hashes v0.7.6
    Compiling pin-utils v0.1.0
    Compiling fnv v1.0.7
    Compiling genawaiter-macro v0.99.1
    Compiling parse_arg v0.1.4
    Compiling chunked_transfer v0.3.1
    Compiling itoa v0.4.8
    Compiling either v1.6.1
    Compiling bech32 v0.7.3
    Compiling hashbrown v0.11.2
    Compiling arrayvec v0.5.2
    Compiling unsigned-varint v0.2.3
    Compiling hex v0.3.2
    Compiling version-compare v0.0.10
    Compiling libloading v0.7.0
    Compiling instant v0.1.10
    Compiling value-bag v1.0.0-alpha.7
    Compiling nom v6.1.2
    Compiling generic-array v0.14.4
    Compiling proc-macro-error-attr v0.4.12
    Compiling proc-macro-error v0.4.12
    Compiling error-chain v0.12.4
    Compiling num-traits v0.2.14
    Compiling memoffset v0.6.4
    Compiling num-integer v0.1.44
    Compiling miniz_oxide v0.4.4
    Compiling indexmap v1.7.0
    Compiling rayon v1.5.1
    Compiling textwrap v0.11.0
    Compiling clang-sys v1.2.2
    Compiling concurrent-queue v1.2.2
 error[E0658]: use of unstable library feature 'str_strip': newly added
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-1.2.2/build/dynamic.rs:93:51
    |
 93 |     let version = if let Some(version) = filename.strip_prefix("libclang.so.") {
    |                                                   ^^^^^^^^^^^^
    |
    = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information
 
 error[E0658]: use of unstable library feature 'str_strip': newly added
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-1.2.2/build/static.rs:27:36
    |
 27 |         if let Some(name) = string.strip_prefix("lib") {
    |                                    ^^^^^^^^^^^^
    |
    = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information
 
 error[E0658]: use of unstable library feature 'str_strip': newly added
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-1.2.2/build/static.rs:44:35
    |
 44 |             if let Some(path) = p.strip_prefix("-l") {
    |                                   ^^^^^^^^^^^^
    |
    = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information
 
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.
 error: could not compile `clang-sys`.
 
 To learn more, run the command again with --verbose.
 warning: build failed, waiting for other jobs to finish...
 error: failed to compile `electrscash v3.0.0 (/home/user)`, intermediate artifacts can be found at `/home/user/target`
 
 Caused by:
   build failed
```
fix docker build error due to missing make tool
similar issue and fix: https://github.com/mit-pdos/noria/issues/138
``` bash
> [7/7] RUN cargo install --path .:
   Installing electrscash v3.0.0 (/home/user)
     Updating crates.io index
  Downloading crates ...
   Downloaded ctor v0.1.21
   Downloaded dirs-sys-next v0.1.2
   Downloaded fastrand v1.5.0
   Downloaded error-chain v0.12.4
   Downloaded env_logger v0.8.4
   Downloaded kv-log-macro v1.0.7
   Downloaded polling v2.1.0
   Downloaded peeking_take_while v0.1.2
   Downloaded shlex v1.1.0
   Downloaded rocksdb v0.15.0
   Downloaded secp256k1-sys v0.3.0
   Downloaded backtrace v0.3.61
   Downloaded bech32 v0.7.3
   Downloaded clang-sys v1.2.2
   Downloaded async-task v4.0.3
   Downloaded bindgen v0.59.1
   Downloaded secp256k1 v0.19.0
   Downloaded miniz_oxide v0.4.4
   Downloaded rust_decimal v1.15.0
   Downloaded stderrlog v0.4.3
   Downloaded lazy_static v0.2.11
   Downloaded rayon v1.5.1
   Downloaded gimli v0.25.0
   Downloaded rustc-demangle v0.1.21
   Downloaded rustc-hash v1.1.0
   Downloaded value-bag v1.0.0-alpha.7
   Downloaded lazycell v1.3.0
   Downloaded lazy_static v1.4.0
   Downloaded which v3.1.1
   Downloaded version-compare v0.0.10
   Downloaded pin-project-lite v0.2.7
   Downloaded sha2 v0.9.8
   Downloaded regex v1.5.4
   Downloaded rand_core v0.5.1
   Downloaded strsim v0.8.0
   Downloaded vec_map v0.8.2
   Downloaded thiserror-impl v1.0.29
   Downloaded unreachable v1.0.0
   Downloaded wyz v0.2.0
   Downloaded void v1.0.2
   Downloaded winapi v0.2.8
   Downloaded url v1.7.2
   Downloaded sysconf v0.3.4
   Downloaded jemallocator v0.3.2
   Downloaded unsigned-varint v0.2.3
   Downloaded genawaiter-macro v0.99.1
   Downloaded configure_me v0.3.4
   Downloaded dirs-next v2.0.0
   Downloaded atomic-waker v1.0.0
   Downloaded configure_me_codegen v0.3.14
   Downloaded cashaccount-sys v0.1.1
   Downloaded bitcoin_hashes v0.7.6
   Downloaded jemalloc-sys v0.3.2
   Downloaded httpcodec v0.2.3
   Downloaded roff v0.1.0
   Downloaded getrandom v0.1.16
   Downloaded matches v0.1.9
   Downloaded radium v0.5.3
   Downloaded textwrap v0.11.0
   Downloaded serde_json v1.0.67
   Downloaded trackable_derive v1.0.0
   Downloaded toml v0.5.8
   Downloaded cfg-if v1.0.0
   Downloaded crossbeam-utils v0.8.5
   Downloaded chrono v0.4.19
   Downloaded futures-core v0.3.17
   Downloaded indexmap v1.7.0
   Downloaded termcolor v1.1.2
   Downloaded jemalloc-ctl v0.3.3
   Downloaded syn-mid v0.5.3
   Downloaded tiny_http v0.6.4
   Downloaded itoa v0.4.8
   Downloaded crossbeam-utils v0.6.6
   Downloaded idna v0.1.5
   Downloaded memoffset v0.6.4
   Downloaded instant v0.1.10
   Downloaded humantime v2.1.0
   Downloaded futures-lite v1.12.0
   Downloaded futures-io v0.3.17
   Downloaded funty v1.1.0
   Downloaded digest v0.9.0
   Downloaded errno v0.2.7
   Downloaded either v1.6.1
   Downloaded byteorder v1.4.3
   Downloaded cargo_toml v0.8.1
   Downloaded cfg-if v0.1.10
   Downloaded cache-padded v1.1.1
   Downloaded trackable v1.2.0
   Downloaded trackable v0.2.24
   Downloaded time v0.1.43
   Downloaded nom v6.1.2
   Downloaded serde_derive v1.0.130
   Downloaded serde v1.0.130
   Downloaded parking_lot_core v0.8.5
   Downloaded slab v0.4.4
   Downloaded signal-hook-registry v1.4.0
   Downloaded signal-hook v0.1.17
   Downloaded sha-1 v0.9.8
   Downloaded parking_lot v0.11.2
   Downloaded ppv-lite86 v0.2.10
   Downloaded memchr v2.4.1
   Downloaded log v0.4.14
   Downloaded bitcoincash v0.25.2
   Downloaded async-global-executor v2.0.2
   Downloaded bitcoincash-addr v0.5.2
   Downloaded atty v0.2.11
   Downloaded chunked_transfer v0.3.1
   Downloaded ascii v0.8.7
   Downloaded rayon-core v1.9.1
   Downloaded hex v0.3.2
   Downloaded fmt2io v0.1.0
   Downloaded winapi-build v0.1.1
   Downloaded version_check v0.9.3
   Downloaded typenum v1.14.0
   Downloaded unicode-normalization v0.1.19
   Downloaded syn v1.0.76
   Downloaded thiserror v1.0.29
   Downloaded thread_local v0.3.4
   Downloaded percent-encoding v1.0.1
   Downloaded bitcoin_hashes v0.9.7
   Downloaded blocking v1.0.2
   Downloaded bitflags v1.3.2
   Downloaded crossbeam-deque v0.8.1
   Downloaded genawaiter-proc-macro v0.99.1
   Downloaded c_fixed_string v0.2.0
   Downloaded paste v0.1.18
   Downloaded page_size v0.4.2
   Downloaded proc-macro-error-attr v0.4.12
   Downloaded aho-corasick v0.7.18
   Downloaded object v0.26.2
   Downloaded cexpr v0.5.0
   Downloaded bytecodec v0.4.15
   Downloaded bitvec v0.19.5
   Downloaded async-std v1.10.0
   Downloaded autocfg v1.0.1
   Downloaded async-lock v2.4.0
   Downloaded async-channel v1.6.1
   Downloaded arrayvec v0.5.2
   Downloaded librocksdb-sys v6.20.3
   Downloaded parse_arg v0.1.4
 warning: spurious network error (2 tries remaining): [55] Failed sending data to the peer (Connection died, tried 5 times before giving up)
   Downloaded genawaiter v0.99.1
   Downloaded unicode-xid v0.2.2
   Downloaded unicode-width v0.1.8
   Downloaded unicode-segmentation v1.8.0
   Downloaded unicode-bidi v0.3.6
   Downloaded tinyvec_macros v0.1.0
   Downloaded tinyvec v1.3.1
   Downloaded tap v1.0.1
   Downloaded socket2 v0.4.1
   Downloaded smallvec v1.6.1
   Downloaded regex-syntax v0.6.25
   Downloaded proc-macro2 v1.0.29
   Downloaded rand_chacha v0.2.2
   Downloaded adler v1.0.2
   Downloaded rand v0.7.3
   Downloaded ansi_term v0.11.0
   Downloaded scopeguard v1.1.0
   Downloaded ryu v1.0.5
   Downloaded quote v1.0.9
   Downloaded proc-macro-hack v0.5.19
   Downloaded pin-utils v0.1.0
   Downloaded opaque-debug v0.3.0
   Downloaded once_cell v1.8.0
   Downloaded num_cpus v1.13.0
   Downloaded num-traits v0.2.14
   Downloaded num-integer v0.1.44
   Downloaded lock_api v0.4.5
   Downloaded waker-fn v1.1.0
   Downloaded libc v0.2.101
   Downloaded hashbrown v0.11.2
   Downloaded crossbeam-channel v0.5.1
   Downloaded clap v2.33.3
   Downloaded man v0.1.1
   Downloaded kernel32-sys v0.2.2
   Downloaded glob v0.3.0
   Downloaded generic-array v0.14.4
   Downloaded fnv v1.0.7
   Downloaded event-listener v2.5.1
   Downloaded toml v0.4.10
   Downloaded cc v1.0.70
   Downloaded cpufeatures v0.2.1
   Downloaded bincode v1.3.3
   Downloaded parking v2.0.0
   Downloaded addr2line v0.16.0
   Downloaded concurrent-queue v1.2.2
   Downloaded base64 v0.10.1
   Downloaded protobuf v2.14.0
   Downloaded fs_extra v1.2.0
   Downloaded async-executor v1.4.1
   Downloaded async-mutex v1.4.0
   Downloaded async-io v1.6.0
   Downloaded prometheus v0.11.0
   Downloaded proc-macro-error v0.4.12
   Downloaded libloading v0.7.0
   Downloaded paste-impl v0.1.18
   Downloaded crossbeam-channel v0.3.9
   Downloaded jobserver v0.1.24
   Downloaded crossbeam-epoch v0.9.5
   Downloaded block-buffer v0.9.0
    Compiling libc v0.2.101
    Compiling proc-macro2 v1.0.29
    Compiling version_check v0.9.3
    Compiling unicode-xid v0.2.2
    Compiling syn v1.0.76
    Compiling memchr v2.4.1
    Compiling autocfg v1.0.1
    Compiling cfg-if v1.0.0
    Compiling serde v1.0.130
    Compiling log v0.4.14
    Compiling radium v0.5.3
    Compiling glob v0.3.0
    Compiling funty v1.1.0
    Compiling tap v1.0.1
    Compiling wyz v0.2.0
    Compiling lazy_static v1.4.0
    Compiling unicode-width v0.1.8
    Compiling regex-syntax v0.6.25
    Compiling ansi_term v0.11.0
    Compiling termcolor v1.1.2
    Compiling futures-core v0.3.17
    Compiling serde_derive v1.0.130
    Compiling humantime v2.1.0
    Compiling strsim v0.8.0
    Compiling bitflags v1.3.2
    Compiling bindgen v0.59.1
    Compiling vec_map v0.8.2
    Compiling rustc-hash v1.1.0
    Compiling shlex v1.1.0
    Compiling crossbeam-utils v0.8.5
    Compiling lazycell v1.3.0
    Compiling peeking_take_while v0.1.2
    Compiling cache-padded v1.1.1
    Compiling scopeguard v1.1.0
    Compiling proc-macro-hack v0.5.19
    Compiling typenum v1.14.0
    Compiling waker-fn v1.1.0
    Compiling event-listener v2.5.1
    Compiling parking v2.0.0
    Compiling fastrand v1.5.0
    Compiling futures-io v0.3.17
    Compiling pin-project-lite v0.2.7
    Compiling configure_me_codegen v0.3.14
    Compiling once_cell v1.8.0
    Compiling fs_extra v1.2.0
    Compiling crossbeam-epoch v0.9.5
    Compiling tinyvec_macros v0.1.0
    Compiling getrandom v0.1.16
    Compiling parking_lot_core v0.8.5
    Compiling rayon-core v1.9.1
    Compiling slab v0.4.4
    Compiling roff v0.1.0
    Compiling void v1.0.2
    Compiling async-task v4.0.3
    Compiling winapi-build v0.1.1
    Compiling fmt2io v0.1.0
    Compiling protobuf v2.14.0
    Compiling atomic-waker v1.0.0
    Compiling smallvec v1.6.1
    Compiling unicode-segmentation v1.8.0
    Compiling ryu v1.0.5
    Compiling gimli v0.25.0
    Compiling unicode-bidi v0.3.6
    Compiling adler v1.0.2
    Compiling byteorder v1.4.3
    Compiling matches v0.1.9
    Compiling serde_json v1.0.67
    Compiling winapi v0.2.8
    Compiling cpufeatures v0.2.1
    Compiling ppv-lite86 v0.2.10
    Compiling opaque-debug v0.3.0
    Compiling rustc-demangle v0.1.21
    Compiling lazy_static v0.2.11
    Compiling percent-encoding v1.0.1
    Compiling cfg-if v0.1.10
    Compiling prometheus v0.11.0
    Compiling arrayvec v0.5.2
    Compiling ascii v0.8.7
    Compiling hashbrown v0.11.2
    Compiling fnv v1.0.7
    Compiling bitcoin_hashes v0.7.6
    Compiling itoa v0.4.8
    Compiling pin-utils v0.1.0
    Compiling chunked_transfer v0.3.1
    Compiling bech32 v0.7.3
    Compiling parse_arg v0.1.4
    Compiling either v1.6.1
    Compiling genawaiter-macro v0.99.1
    Compiling hex v0.3.2
    Compiling version-compare v0.0.10
    Compiling unsigned-varint v0.2.3
    Compiling value-bag v1.0.0-alpha.7
    Compiling nom v6.1.2
    Compiling generic-array v0.14.4
    Compiling proc-macro-error-attr v0.4.12
    Compiling proc-macro-error v0.4.12
    Compiling error-chain v0.12.4
    Compiling instant v0.1.10
    Compiling num-traits v0.2.14
    Compiling memoffset v0.6.4
    Compiling num-integer v0.1.44
    Compiling miniz_oxide v0.4.4
    Compiling indexmap v1.7.0
    Compiling rayon v1.5.1
    Compiling libloading v0.7.0
    Compiling textwrap v0.11.0
    Compiling clang-sys v1.2.2
    Compiling concurrent-queue v1.2.2
    Compiling lock_api v0.4.5
    Compiling async-mutex v1.4.0
    Compiling async-lock v2.4.0
    Compiling tinyvec v1.3.1
    Compiling man v0.1.1
    Compiling unreachable v1.0.0
    Compiling kernel32-sys v0.2.2
    Compiling base64 v0.10.1
    Compiling addr2line v0.16.0
    Compiling crossbeam-utils v0.6.6
    Compiling bitcoincash-addr v0.5.2
    Compiling thread_local v0.3.4
    Compiling unicode-normalization v0.1.19
    Compiling crossbeam-channel v0.3.9
    Compiling num_cpus v1.13.0
    Compiling socket2 v0.4.1
    Compiling time v0.1.43
    Compiling dirs-sys-next v0.1.2
    Compiling signal-hook-registry v1.4.0
    Compiling atty v0.2.11
    Compiling errno v0.2.7
    Compiling page_size v0.4.2
    Compiling jobserver v0.1.24
    Compiling which v3.1.1
    Compiling quote v1.0.9
    Compiling object v0.26.2
    Compiling aho-corasick v0.7.18
    Compiling c_fixed_string v0.2.0
    Compiling bitvec v0.19.5
    Compiling futures-lite v1.12.0
    Compiling async-channel v1.6.1
    Compiling crossbeam-channel v0.5.1
    Compiling toml v0.5.8
    Compiling toml v0.4.10
    Compiling bitcoin_hashes v0.9.7
    Compiling bincode v1.3.3
    Compiling paste-impl v0.1.18
    Compiling idna v0.1.5
    Compiling rand_core v0.5.1
    Compiling parking_lot v0.11.2
    Compiling dirs-next v2.0.0
    Compiling signal-hook v0.1.17
    Compiling clap v2.33.3
    Compiling cc v1.0.70
    Compiling regex v1.5.4
    Compiling rust_decimal v1.15.0
    Compiling async-executor v1.4.1
    Compiling blocking v1.0.2
    Compiling paste v0.1.18
    Compiling sysconf v0.3.4
    Compiling block-buffer v0.9.0
    Compiling digest v0.9.0
    Compiling url v1.7.2
    Compiling rand_chacha v0.2.2
    Compiling secp256k1-sys v0.3.0
    Compiling jemalloc-sys v0.3.2
    Compiling backtrace v0.3.61
    Compiling syn-mid v0.5.3
    Compiling ctor v0.1.21
    Compiling trackable_derive v1.0.0
    Compiling thiserror-impl v1.0.29
    Compiling crossbeam-deque v0.8.1
    Compiling chrono v0.4.19
    Compiling sha2 v0.9.8
    Compiling sha-1 v0.9.8
    Compiling cexpr v0.5.0
    Compiling rand v0.7.3
    Compiling trackable v1.2.0
    Compiling thiserror v1.0.29
    Compiling cargo_toml v0.8.1
 error: failed to run custom build command for `jemalloc-sys v0.3.2`
 
 Caused by:
   process didn't exit successfully: `/home/user/target/release/build/jemalloc-sys-9405f2dba11ce350/build-script-build` (exit status: 101)
   --- stdout
   TARGET=x86_64-unknown-linux-gnu
   HOST=x86_64-unknown-linux-gnu
   NUM_JOBS=4
   OUT_DIR="/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out"
   BUILD_DIR="/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/build"
   SRC_DIR="/usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/jemalloc-sys-0.3.2"
   OPT_LEVEL = Some("3")
   TARGET = Some("x86_64-unknown-linux-gnu")
   HOST = Some("x86_64-unknown-linux-gnu")
   CC_x86_64-unknown-linux-gnu = None
   CC_x86_64_unknown_linux_gnu = None
   HOST_CC = None
   CC = None
   CFLAGS_x86_64-unknown-linux-gnu = None
   CFLAGS_x86_64_unknown_linux_gnu = None
   HOST_CFLAGS = None
   CFLAGS = None
   CRATE_CC_NO_DEFAULTS = None
   DEBUG = Some("false")
   CARGO_CFG_TARGET_FEATURE = Some("fxsr,sse,sse2")
   CC="cc"
   CFLAGS="-O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall"
   JEMALLOC_REPO_DIR="jemalloc"
   JEMALLOC_SRC_DIR="/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/jemalloc"
   cargo:rustc-cfg=prefixed
   --with-jemalloc-prefix=_rjem_
   running: "sh" "/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/jemalloc/configure" "--disable-cxx" "--with-jemalloc-prefix=_rjem_" "--with-private-namespace=_rjem_" "--host=x86_64-unknown-linux-gnu" "--build=x86_64-unknown-linux-gnu" "--prefix=/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out"
   checking for xsltproc... false
   checking for x86_64-unknown-linux-gnu-gcc... cc
   checking whether the C compiler works... yes
   checking for C compiler default output file name... a.out
   checking for suffix of executables... 
   checking whether we are cross compiling... no
   checking for suffix of object files... o
   checking whether we are using the GNU C compiler... yes
   checking whether cc accepts -g... yes
   checking for cc option to accept ISO C89... none needed
   checking whether compiler is cray... no
   checking whether compiler supports -std=gnu11... yes
   checking whether compiler supports -Wall... yes
   checking whether compiler supports -Wshorten-64-to-32... no
   checking whether compiler supports -Wsign-compare... yes
   checking whether compiler supports -Wundef... yes
   checking whether compiler supports -Wno-format-zero-length... yes
   checking whether compiler supports -pipe... yes
   checking whether compiler supports -g3... yes
   checking how to run the C preprocessor... cc -E
   checking for grep that handles long lines and -e... /bin/grep
   checking for egrep... /bin/grep -E
   checking for ANSI C header files... yes
   checking for sys/types.h... yes
   checking for sys/stat.h... yes
   checking for stdlib.h... yes
   checking for string.h... yes
   checking for memory.h... yes
   checking for strings.h... yes
   checking for inttypes.h... yes
   checking for stdint.h... yes
   checking for unistd.h... yes
   checking whether byte ordering is bigendian... no
   checking size of void *... 8
   checking size of int... 4
   checking size of long... 8
   checking size of long long... 8
   checking size of intmax_t... 8
   checking build system type... x86_64-unknown-linux-gnu
   checking host system type... x86_64-unknown-linux-gnu
   checking whether pause instruction is compilable... yes
   checking number of significant virtual address bits... 48
   checking for x86_64-unknown-linux-gnu-ar... no
   checking for ar... ar
   checking for x86_64-unknown-linux-gnu-nm... no
   checking for nm... nm
   checking for gawk... no
   checking for mawk... mawk
   checking malloc.h usability... yes
   checking malloc.h presence... yes
   checking for malloc.h... yes
   checking whether malloc_usable_size definition can use const argument... no
   checking for library containing log... -lm
   checking whether __attribute__ syntax is compilable... yes
   checking whether compiler supports -fvisibility=hidden... yes
   checking whether compiler supports -fvisibility=hidden... no
   checking whether compiler supports -Werror... yes
   checking whether compiler supports -herror_on_warning... no
   checking whether tls_model attribute is compilable... yes
   checking whether compiler supports -Werror... yes
   checking whether compiler supports -herror_on_warning... no
   checking whether alloc_size attribute is compilable... yes
   checking whether compiler supports -Werror... yes
   checking whether compiler supports -herror_on_warning... no
   checking whether format(gnu_printf, ...) attribute is compilable... yes
   checking whether compiler supports -Werror... yes
   checking whether compiler supports -herror_on_warning... no
   checking whether format(printf, ...) attribute is compilable... yes
   checking for a BSD-compatible install... /usr/bin/install -c
   checking for x86_64-unknown-linux-gnu-ranlib... no
   checking for ranlib... ranlib
   checking for ld... /usr/bin/ld
   checking for autoconf... false
   checking for memalign... yes
   checking for valloc... yes
   checking whether compiler supports -O3... yes
   checking whether compiler supports -O3... no
   checking whether compiler supports -funroll-loops... yes
   checking configured backtracing method... N/A
   checking for sbrk... yes
   checking whether utrace(2) is compilable... no
   checking whether a program using __builtin_unreachable is compilable... yes
   checking whether a program using __builtin_ffsl is compilable... yes
   checking LG_PAGE... 12
   Missing VERSION file, and unable to generate it; creating bogus VERSION
   checking pthread.h usability... yes
   checking pthread.h presence... yes
   checking for pthread.h... yes
   checking for pthread_create in -lpthread... yes
   checking dlfcn.h usability... yes
   checking dlfcn.h presence... yes
   checking for dlfcn.h... yes
   checking for dlsym... no
   checking for dlsym in -ldl... yes
   checking whether pthread_atfork(3) is compilable... yes
   checking whether pthread_setname_np(3) is compilable... yes
   checking for library containing clock_gettime... none required
   checking whether clock_gettime(CLOCK_MONOTONIC_COARSE, ...) is compilable... yes
   checking whether clock_gettime(CLOCK_MONOTONIC, ...) is compilable... yes
   checking whether mach_absolute_time() is compilable... no
   checking whether compiler supports -Werror... yes
   checking whether syscall(2) is compilable... yes
   checking for secure_getenv... yes
   checking for sched_getcpu... yes
   checking for sched_setaffinity... yes
   checking for issetugid... no
   checking for _malloc_thread_cleanup... no
   checking for _pthread_mutex_init_calloc_cb... no
   checking for TLS... yes
   checking whether C11 atomics is compilable... yes
   checking whether GCC __atomic atomics is compilable... yes
   checking whether GCC __sync atomics is compilable... yes
   checking whether Darwin OSAtomic*() is compilable... no
   checking whether madvise(2) is compilable... yes
   checking whether madvise(..., MADV_FREE) is compilable... yes
   checking whether madvise(..., MADV_DONTNEED) is compilable... yes
   checking whether madvise(..., MADV_DO[NT]DUMP) is compilable... yes
   checking whether madvise(..., MADV_[NO]HUGEPAGE) is compilable... yes
   checking whether to force 32-bit __sync_{add,sub}_and_fetch()... no
   checking whether to force 64-bit __sync_{add,sub}_and_fetch()... no
   checking for __builtin_clz... yes
   checking whether Darwin os_unfair_lock_*() is compilable... no
   checking whether Darwin OSSpin*() is compilable... no
   checking whether glibc malloc hook is compilable... yes
   checking whether glibc memalign hook is compilable... yes
   checking whether pthreads adaptive mutexes is compilable... yes
   checking whether compiler supports -D_GNU_SOURCE... yes
   checking whether compiler supports -Werror... yes
   checking whether compiler supports -herror_on_warning... no
   checking whether strerror_r returns char with gnu source is compilable... yes
   checking for stdbool.h that conforms to C99... yes
   checking for _Bool... yes
   configure: creating ./config.status
   config.status: creating Makefile
   config.status: creating jemalloc.pc
   config.status: creating doc/html.xsl
   config.status: creating doc/manpages.xsl
   config.status: creating doc/jemalloc.xml
   config.status: creating include/jemalloc/jemalloc_macros.h
   config.status: creating include/jemalloc/jemalloc_protos.h
   config.status: creating include/jemalloc/jemalloc_typedefs.h
   config.status: creating include/jemalloc/internal/jemalloc_preamble.h
   config.status: creating test/test.sh
   config.status: creating test/include/test/jemalloc_test.h
   config.status: creating config.stamp
   config.status: creating bin/jemalloc-config
   config.status: creating bin/jemalloc.sh
   config.status: creating bin/jeprof
   config.status: creating include/jemalloc/jemalloc_defs.h
   config.status: creating include/jemalloc/internal/jemalloc_internal_defs.h
   config.status: creating test/include/test/jemalloc_test_defs.h
   config.status: executing include/jemalloc/internal/public_symbols.txt commands
   config.status: executing include/jemalloc/internal/private_symbols.awk commands
   config.status: executing include/jemalloc/internal/private_symbols_jet.awk commands
   config.status: executing include/jemalloc/internal/public_namespace.h commands
   config.status: executing include/jemalloc/internal/public_unnamespace.h commands
   config.status: executing include/jemalloc/internal/size_classes.h commands
   config.status: executing include/jemalloc/jemalloc_protos_jet.h commands
   config.status: executing include/jemalloc/jemalloc_rename.h commands
   config.status: executing include/jemalloc/jemalloc_mangle.h commands
   config.status: executing include/jemalloc/jemalloc_mangle_jet.h commands
   config.status: executing include/jemalloc/jemalloc.h commands
   ===============================================================================
   jemalloc version   : 0.0.0-0-g0000000000000000000000000000000000000000
   library revision   : 2
 
   CONFIG             : --disable-cxx --with-jemalloc-prefix=_rjem_ --with-private-namespace=_rjem_ --host=x86_64-unknown-linux-gnu --build=x86_64-unknown-linux-gnu --prefix=/home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out build_alias=x86_64-unknown-linux-gnu host_alias=x86_64-unknown-linux-gnu CC=cc 'CFLAGS=-O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall' 'LDFLAGS=-O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall' 'CPPFLAGS=-O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall'
   CC                 : cc
   CONFIGURE_CFLAGS   : -std=gnu11 -Wall -Wsign-compare -Wundef -Wno-format-zero-length -pipe -g3 -fvisibility=hidden -O3 -funroll-loops
   SPECIFIED_CFLAGS   : -O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall
   EXTRA_CFLAGS       : 
   CPPFLAGS           : -O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall -D_GNU_SOURCE -D_REENTRANT
   CXX                : 
   CONFIGURE_CXXFLAGS : 
   SPECIFIED_CXXFLAGS : 
   EXTRA_CXXFLAGS     : 
   LDFLAGS            : -O3 -ffunction-sections -fdata-sections -fPIC -m64 -Wall
   EXTRA_LDFLAGS      : 
   DSO_LDFLAGS        : -shared -Wl,-soname,$(@F)
   LIBS               : -lm  -lpthread -ldl
   RPATH_EXTRA        : 
 
   XSLTPROC           : false
   XSLROOT            : 
 
   PREFIX             : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out
   BINDIR             : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/bin
   DATADIR            : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/share
   INCLUDEDIR         : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/include
   LIBDIR             : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/lib
   MANDIR             : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/share/man
 
   srcroot            : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/jemalloc/
   abs_srcroot        : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/jemalloc/
   objroot            : 
   abs_objroot        : /home/user/target/release/build/jemalloc-sys-79afebe7b15b8b35/out/build/
 
   JEMALLOC_PREFIX    : _rjem_
   JEMALLOC_PRIVATE_NAMESPACE
                      : _rjem_je_
   install_suffix     : 
   malloc_conf        : 
   autogen            : 0
   debug              : 0
   stats              : 1
   prof               : 0
   prof-libunwind     : 0
   prof-libgcc        : 0
   prof-gcc           : 0
   fill               : 1
   utrace             : 0
   xmalloc            : 0
   log                : 0
   lazy_lock          : 0
   cache-oblivious    : 1
   cxx                : 0
   ===============================================================================
   running: "make" "srcroot=../jemalloc/" "-j" "4"
 
   --- stderr
   thread 'main' panicked at 'failed to execute command: No such file or directory (os error 2)', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/jemalloc-sys-0.3.2/build.rs:389:19
   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 warning: build failed, waiting for other jobs to finish...
 error: failed to compile `electrscash v3.0.0 (/home/user)`, intermediate artifacts can be found at `/home/user/target`
 
 Caused by:
   build failed
```